### PR TITLE
Feature implementation from commits 06e2f2c..40dedd7

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6717,6 +6717,25 @@ Description
       and ``{_filename}``.
 
 
+exec.commands
+-------------
+Type
+    ``list`` of `commands <exec.command_>`__
+Example
+    .. code:: json
+
+        [
+            ["echo", "{user[account]}", "{id}"]
+            ["magick", "convert" "{_path}",  "\fF {_path.rpartition('.')[0]}.png"],
+            "rm {}",
+        ]
+Description
+    Multiple `commands <exec.command_>`__ to run in succession.
+
+    All `commands <exec.command_>`__ after the first returning with a non-zero
+    exit status will not be run.
+
+
 exec.event
 ----------
 Type

--- a/gallery_dl/__init__.py
+++ b/gallery_dl/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/__init__.py
+++ b/gallery_dl/__init__.py
@@ -273,8 +273,7 @@ def main():
                 jobtype = job.UrlJob
                 jobtype.maxdepth = args.list_urls
                 if config.get(("output",), "fallback", True):
-                    jobtype.handle_url = \
-                        staticmethod(jobtype.handle_url_fallback)
+                    jobtype.handle_url = jobtype.handle_url_fallback
             elif args.dump_json:
                 jobtype = job.DataJob
                 jobtype.resolve = args.dump_json - 1
@@ -549,13 +548,11 @@ class InputManager():
                 "Unable to update '%s' (%s: %s)",
                 path, exc.__class__.__name__, exc)
 
-    @staticmethod
-    def _action_comment(lines, indicies):
+    def _action_comment(self, lines, indicies):
         for i in indicies:
             lines[i] = "# " + lines[i]
 
-    @staticmethod
-    def _action_delete(lines, indicies):
+    def _action_delete(self, lines, indicies):
         for i in indicies:
             lines[i] = ""
 

--- a/gallery_dl/config.py
+++ b/gallery_dl/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/cookies.py
+++ b/gallery_dl/cookies.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/cookies.py
+++ b/gallery_dl/cookies.py
@@ -524,8 +524,7 @@ class LinuxChromiumCookieDecryptor(ChromiumCookieDecryptor):
         self._cookie_counts = {"v10": 0, "v11": 0, "other": 0}
         self._offset = (32 if meta_version >= 24 else 0)
 
-    @staticmethod
-    def derive_key(password):
+    def derive_key(self, password):
         # values from
         # https://chromium.googlesource.com/chromium/src/+/refs/heads
         # /main/components/os_crypt/os_crypt_linux.cc
@@ -569,8 +568,7 @@ class MacChromiumCookieDecryptor(ChromiumCookieDecryptor):
         self._cookie_counts = {"v10": 0, "other": 0}
         self._offset = (32 if meta_version >= 24 else 0)
 
-    @staticmethod
-    def derive_key(password):
+    def derive_key(self, password):
         # values from
         # https://chromium.googlesource.com/chromium/src/+/refs/heads
         # /main/components/os_crypt/os_crypt_mac.mm

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -360,8 +360,7 @@ class HttpDownloader(DownloaderBase):
                 "closing the connection anyway", exc.__class__.__name__, exc)
             response.close()
 
-    @staticmethod
-    def receive(fp, content, bytes_total, bytes_start):
+    def receive(self, fp, content, bytes_total, bytes_start):
         write = fp.write
         for data in content:
             write(data)
@@ -411,8 +410,7 @@ class HttpDownloader(DownloaderBase):
         self.log.warning("Unknown MIME type '%s'", mtype)
         return "bin"
 
-    @staticmethod
-    def _adjust_extension(pathfmt, file_header):
+    def _adjust_extension(self, pathfmt, file_header):
         """Check filename extension against file header"""
         if not SIGNATURE_CHECKS[pathfmt.extension](file_header):
             for ext, check in SIGNATURE_CHECKS.items():

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -469,11 +469,18 @@ MIME_TYPES = {
     "application/x-pdf": "pdf",
     "application/x-shockwave-flash": "swf",
 
+    "text/html": "html",
+
     "application/ogg": "ogg",
     # https://www.iana.org/assignments/media-types/model/obj
     "model/obj": "obj",
     "application/octet-stream": "bin",
 }
+
+
+def _signature_html(s):
+    return b"<!doctype html".startswith(s[:14].lower())
+
 
 # https://en.wikipedia.org/wiki/List_of_file_signatures
 SIGNATURE_CHECKS = {
@@ -505,6 +512,8 @@ SIGNATURE_CHECKS = {
     "7z"  : lambda s: s[0:6] == b"\x37\x7A\xBC\xAF\x27\x1C",
     "pdf" : lambda s: s[0:5] == b"%PDF-",
     "swf" : lambda s: s[0:3] in (b"CWS", b"FWS"),
+    "html": _signature_html,
+    "htm" : _signature_html,
     "blend": lambda s: s[0:7] == b"BLENDER",
     # unfortunately the Wavefront .obj format doesn't have a signature,
     # so we check for the existence of Blender's comment

--- a/gallery_dl/downloader/ytdl.py
+++ b/gallery_dl/downloader/ytdl.py
@@ -233,8 +233,7 @@ class YoutubeDLDownloader(DownloaderBase):
                 int(speed) if speed else 0,
             )
 
-    @staticmethod
-    def _set_outtmpl(ytdl_instance, outtmpl):
+    def _set_outtmpl(self, ytdl_instance, outtmpl):
         try:
             ytdl_instance._parse_outtmpl
         except AttributeError:

--- a/gallery_dl/downloader/ytdl.py
+++ b/gallery_dl/downloader/ytdl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2022 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/2chan.py
+++ b/gallery_dl/extractor/2chan.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/2chan.py
+++ b/gallery_dl/extractor/2chan.py
@@ -74,8 +74,7 @@ class _2chanThreadExtractor(Extractor):
             data["ext"] = "." + data["extension"]
         return data
 
-    @staticmethod
-    def _extract_post(post):
+    def _extract_post(self, post):
         return text.extract_all(post, (
             ("post", 'class="csb">'   , '<'),
             ("name", 'class="cnm">'   , '<'),
@@ -85,8 +84,7 @@ class _2chanThreadExtractor(Extractor):
             ("com" , '>', '</blockquote>'),
         ))[0]
 
-    @staticmethod
-    def _extract_image(post, data):
+    def _extract_image(self, post, data):
         text.extract_all(post, (
             (None      , '_blank', ''),
             ("filename", '>', '<'),

--- a/gallery_dl/extractor/35photo.py
+++ b/gallery_dl/extractor/35photo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/35photo.py
+++ b/gallery_dl/extractor/35photo.py
@@ -83,8 +83,7 @@ class _35photoExtractor(Extractor):
             info["num"] = 1
             yield info
 
-    @staticmethod
-    def _photo_ids(page):
+    def _photo_ids(self, page):
         """Extract unique photo IDs and return them as sorted list"""
         #  searching for photo-id="..." doesn't always work (see unit tests)
         if not page:

--- a/gallery_dl/extractor/4archive.py
+++ b/gallery_dl/extractor/4archive.py
@@ -58,8 +58,7 @@ class _4archiveThreadExtractor(Extractor):
             for post in page.split('class="postContainer')[1:]
         ]
 
-    @staticmethod
-    def parse(post):
+    def parse(self, post):
         extr = text.extract_from(post)
         data = {
             "name": extr('class="name">', "</span>"),

--- a/gallery_dl/extractor/4chanarchives.py
+++ b/gallery_dl/extractor/4chanarchives.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/4chanarchives.py
+++ b/gallery_dl/extractor/4chanarchives.py
@@ -66,8 +66,7 @@ class _4chanarchivesThreadExtractor(Extractor):
             post["extension"] = post["url"].rpartition(".")[2]
         return post
 
-    @staticmethod
-    def _extract_post(html):
+    def _extract_post(self, html):
         extr = text.extract_from(html)
         return {
             "no"  : text.parse_int(extr('', '"')),
@@ -77,8 +76,7 @@ class _4chanarchivesThreadExtractor(Extractor):
                 html[html.find('<blockquote'):].partition(">")[2]),
         }
 
-    @staticmethod
-    def _extract_file(html, post):
+    def _extract_file(self, html, post):
         extr = text.extract_from(html, html.index(">File: <"))
         post["url"] = extr('href="', '"')
         post["filename"] = text.unquote(extr(">", "<").rpartition(".")[0])

--- a/gallery_dl/extractor/8muses.py
+++ b/gallery_dl/extractor/8muses.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/8muses.py
+++ b/gallery_dl/extractor/8muses.py
@@ -92,8 +92,7 @@ class _8musesAlbumExtractor(Extractor):
                 album["updatedAt"], "%Y-%m-%dT%H:%M:%S.%fZ"),
         }
 
-    @staticmethod
-    def _unobfuscate(data):
+    def _unobfuscate(self, data):
         return util.json_loads("".join([
             chr(33 + (ord(c) + 14) % 94) if "!" <= c <= "~" else c
             for c in text.unescape(data.strip("\t\n\r !"))

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/adultempire.py
+++ b/gallery_dl/extractor/adultempire.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/agnph.py
+++ b/gallery_dl/extractor/agnph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/ao3.py
+++ b/gallery_dl/extractor/ao3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/architizer.py
+++ b/gallery_dl/extractor/architizer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/artstation.py
+++ b/gallery_dl/extractor/artstation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/artstation.py
+++ b/gallery_dl/extractor/artstation.py
@@ -87,8 +87,7 @@ class ArtstationExtractor(Extractor):
 
                     yield Message.Url, url, asset
 
-    @staticmethod
-    def _image_fallback(lhs, rhs):
+    def _image_fallback(self, lhs, rhs):
         yield lhs + "/large/" + rhs
         yield lhs + "/medium/" + rhs
         yield lhs + "/small/" + rhs
@@ -172,8 +171,7 @@ class ArtstationExtractor(Extractor):
             url, method="POST", headers=headers, json={},
         ).json()["public_csrf_token"]
 
-    @staticmethod
-    def _no_cache(url):
+    def _no_cache(self, url):
         """Cause a cache miss to prevent Cloudflare 'optimizations'
 
         Cloudflare's 'Polish' optimization strips image metadata and may even
@@ -344,8 +342,7 @@ class ArtstationChallengeExtractor(ArtstationExtractor):
                     text.nameext_from_url(url, update)
                     yield Message.Url, self._no_cache(url), update
 
-    @staticmethod
-    def _id_from_url(url):
+    def _id_from_url(self, url):
         """Get an image's submission ID from its URL"""
         parts = url.split("/")
         return text.parse_int("".join(parts[7:10]))

--- a/gallery_dl/extractor/aryion.py
+++ b/gallery_dl/extractor/aryion.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/bbc.py
+++ b/gallery_dl/extractor/bbc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/bbc.py
+++ b/gallery_dl/extractor/bbc.py
@@ -60,8 +60,7 @@ class BbcGalleryExtractor(GalleryExtractor):
             ))
         return results
 
-    @staticmethod
-    def _fallback_urls(src, max_width):
+    def _fallback_urls(self, src, max_width):
         front, _, back = src.partition("/320x180_b/")
         for width in (1920, 1600, 1280, 976):
             if width < max_width:

--- a/gallery_dl/extractor/behance.py
+++ b/gallery_dl/extractor/behance.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/blogger.py
+++ b/gallery_dl/extractor/blogger.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/bluesky.py
+++ b/gallery_dl/extractor/bluesky.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/chevereto.py
+++ b/gallery_dl/extractor/chevereto.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/cien.py
+++ b/gallery_dl/extractor/cien.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/civitai.py
+++ b/gallery_dl/extractor/civitai.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/comicvine.py
+++ b/gallery_dl/extractor/comicvine.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/comicvine.py
+++ b/gallery_dl/extractor/comicvine.py
@@ -59,8 +59,7 @@ class ComicvineTagExtractor(BooruExtractor):
 
     _file_url = operator.itemgetter("original")
 
-    @staticmethod
-    def _prepare(post):
+    def _prepare(self, post):
         post["date"] = text.parse_datetime(
             post["dateCreated"], "%a, %b %d %Y")
         post["tags"] = [tag["name"] for tag in post["tags"] if tag["name"]]

--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -280,8 +280,7 @@ class DeviantartExtractor(Extractor):
             deviation["index_base36"],
         ))
 
-    @staticmethod
-    def commit(deviation, target):
+    def commit(self, deviation, target):
         url = target["src"]
         name = target.get("filename") or url
         target = target.copy()
@@ -680,8 +679,7 @@ x2="45.4107524%" y2="71.4898596%" id="app-root-3">\
 
         return content
 
-    @staticmethod
-    def _find_folder(folders, name, uuid):
+    def _find_folder(self, folders, name, uuid):
         if uuid.isdecimal():
             match = util.re(
                 "(?i)" + name.replace("-", "[^a-z0-9]+") + "$").match
@@ -1889,8 +1887,7 @@ class DeviantartOAuthAPI():
         result.extend(self._pagination(endpoint, params, False, key=key))
         return result
 
-    @staticmethod
-    def _shared_content(results):
+    def _shared_content(self, results):
         """Return an iterable of shared deviations in 'results'"""
         for result in results:
             for item in result.get("items") or ():

--- a/gallery_dl/extractor/directlink.py
+++ b/gallery_dl/extractor/directlink.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/discord.py
+++ b/gallery_dl/extractor/discord.py
@@ -391,8 +391,7 @@ class DiscordAPI():
                 return
             offset += len(data)
 
-    @staticmethod
-    def _raise_invalid_token():
+    def _raise_invalid_token(self):
         raise exception.AuthenticationError("""Invalid or missing token.
 Please provide a valid token following these instructions:
 

--- a/gallery_dl/extractor/dynastyscans.py
+++ b/gallery_dl/extractor/dynastyscans.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/e621.py
+++ b/gallery_dl/extractor/e621.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/erome.py
+++ b/gallery_dl/extractor/erome.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/exhentai.py
+++ b/gallery_dl/extractor/exhentai.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/exhentai.py
+++ b/gallery_dl/extractor/exhentai.py
@@ -534,8 +534,7 @@ class ExhentaiGalleryExtractor(ExhentaiExtractor):
 
             nl = data["_nl"]
 
-    @staticmethod
-    def _parse_image_info(url):
+    def _parse_image_info(self, url):
         for part in url.split("/")[4:]:
             try:
                 _, size, width, height, _ = part.split("-")
@@ -552,8 +551,7 @@ class ExhentaiGalleryExtractor(ExhentaiExtractor):
             "height": text.parse_int(height),
         }
 
-    @staticmethod
-    def _parse_original_info(info):
+    def _parse_original_info(self, info):
         parts = info.lstrip().split(" ")
         size = text.parse_bytes(parts[3] + parts[4][0])
 

--- a/gallery_dl/extractor/facebook.py
+++ b/gallery_dl/extractor/facebook.py
@@ -37,15 +37,13 @@ class FacebookExtractor(Extractor):
         self.videos = self.config("videos", True)
         self.author_followups = self.config("author-followups", False)
 
-    @staticmethod
-    def decode_all(txt):
+    def decode_all(self, txt):
         return text.unescape(
             txt.encode().decode("unicode_escape")
             .encode("utf_16", "surrogatepass").decode("utf_16")
         ).replace("\\/", "/")
 
-    @staticmethod
-    def parse_set_page(set_page):
+    def parse_set_page(self, set_page):
         directory = {
             "set_id": text.extr(
                 set_page, '"mediaSetToken":"', '"'
@@ -77,8 +75,7 @@ class FacebookExtractor(Extractor):
 
         return directory
 
-    @staticmethod
-    def parse_photo_page(photo_page):
+    def parse_photo_page(self, photo_page):
         photo = {
             "id": text.extr(
                 photo_page, '"__isNode":"Photo","id":"', '"'
@@ -133,8 +130,7 @@ class FacebookExtractor(Extractor):
 
         return photo
 
-    @staticmethod
-    def parse_post_page(post_page):
+    def parse_post_page(self, post_page):
         first_photo_url = text.extr(
             text.extr(
                 post_page, '"__isMedia":"Photo"', '"target_group"'
@@ -148,8 +144,7 @@ class FacebookExtractor(Extractor):
 
         return post
 
-    @staticmethod
-    def parse_video_page(video_page):
+    def parse_video_page(self, video_page):
         video = {
             "id": text.extr(
                 video_page, '\\"video_id\\":\\"', '\\"'
@@ -410,8 +405,7 @@ class FacebookProfileExtractor(FacebookExtractor):
     )
     example = "https://www.facebook.com/USERNAME"
 
-    @staticmethod
-    def get_profile_photos_set_id(profile_photos_page):
+    def get_profile_photos_set_id(self, profile_photos_page):
         set_ids_raw = text.extr(
             profile_photos_page, '"pageItems"', '"page_info"'
         )

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -56,6 +56,7 @@ class FantiaExtractor(Extractor):
                         "%s#post-content-id-%s", content["visible_status"],
                         post["post_url"], content["id"])
 
+                post["_http_validate"] = self._validate_response
                 for file in files:
                     post.update(file)
                     post["num"] += 1
@@ -89,6 +90,10 @@ class FantiaExtractor(Extractor):
             page = self.request(self.root + "/").text
         self.headers["X-CSRF-Token"] = text.extr(
             page, 'name="csrf-token" content="', '"')
+
+    def _validate_response(self, response):
+        return not response.history or not response.headers.get(
+            "content-type", "").startswith("text/html")
 
     def _get_post_data(self, post_id):
         """Fetch and process post data"""

--- a/gallery_dl/extractor/flickr.py
+++ b/gallery_dl/extractor/flickr.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/flickr.py
+++ b/gallery_dl/extractor/flickr.py
@@ -585,8 +585,7 @@ class FlickrAPI(oauth.OAuth1API):
         if "license" in photo:
             photo["license_name"] = self.LICENSES.get(photo["license"])
 
-    @staticmethod
-    def _clean_info(info):
+    def _clean_info(self, info):
         info["title"] = info["title"]["_content"]
         info["description"] = info["description"]["_content"]
         return info

--- a/gallery_dl/extractor/foolfuuka.py
+++ b/gallery_dl/extractor/foolfuuka.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/foolfuuka.py
+++ b/gallery_dl/extractor/foolfuuka.py
@@ -74,8 +74,7 @@ class FoolfuukaExtractor(BaseExtractor):
 
         return url
 
-    @staticmethod
-    def _remote_direct(media):
+    def _remote_direct(self, media):
         return media["remote_media_link"]
 
 

--- a/gallery_dl/extractor/foolslide.py
+++ b/gallery_dl/extractor/foolslide.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/foolslide.py
+++ b/gallery_dl/extractor/foolslide.py
@@ -24,8 +24,7 @@ class FoolslideExtractor(BaseExtractor):
         return BaseExtractor.request(
             self, url, encoding="utf-8", method="POST", data={"adult": "true"})
 
-    @staticmethod
-    def parse_chapter_url(url, data):
+    def parse_chapter_url(self, url, data):
         info = url.partition("/read/")[2].rstrip("/").split("/")
         lang = info[1].partition("-")[0]
         data["lang"] = lang

--- a/gallery_dl/extractor/furaffinity.py
+++ b/gallery_dl/extractor/furaffinity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/furaffinity.py
+++ b/gallery_dl/extractor/furaffinity.py
@@ -152,8 +152,7 @@ class FuraffinityExtractor(Extractor):
 
         return data
 
-    @staticmethod
-    def _process_description(description):
+    def _process_description(self, description):
         return text.unescape(text.remove_html(description, "", ""))
 
     def _pagination(self, path, folder=None):

--- a/gallery_dl/extractor/fuskator.py
+++ b/gallery_dl/extractor/fuskator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/gelbooru_v02.py
+++ b/gallery_dl/extractor/gelbooru_v02.py
@@ -89,8 +89,7 @@ class GelbooruV02Extractor(booru.BooruExtractor):
                 return
             params["pid"] += self.per_page
 
-    @staticmethod
-    def _prepare(post):
+    def _prepare(self, post):
         post["tags"] = post["tags"].strip()
         post["date"] = text.parse_datetime(
             post["created_at"], "%a %b %d %H:%M:%S %z %Y")

--- a/gallery_dl/extractor/gelbooru_v02.py
+++ b/gallery_dl/extractor/gelbooru_v02.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2022 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/hentai2read.py
+++ b/gallery_dl/extractor/hentai2read.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/hentaifoundry.py
+++ b/gallery_dl/extractor/hentaifoundry.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/hentaihere.py
+++ b/gallery_dl/extractor/hentaihere.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/hentaihere.py
+++ b/gallery_dl/extractor/hentaihere.py
@@ -49,8 +49,7 @@ class HentaihereChapterExtractor(HentaihereBase, ChapterExtractor):
             "language": "English",
         }
 
-    @staticmethod
-    def images(page):
+    def images(self, page):
         images = text.extr(page, "var rff_imageList = ", ";")
         return [
             ("https://hentaicdn.com/hentai" + part, None)

--- a/gallery_dl/extractor/hentainexus.py
+++ b/gallery_dl/extractor/hentainexus.py
@@ -78,8 +78,7 @@ class HentainexusGalleryExtractor(GalleryExtractor):
                 pass
         return results
 
-    @staticmethod
-    def _decode(data):
+    def _decode(self, data):
         # https://hentainexus.com/static/js/reader.min.js?r=22
         hostname = "hentainexus.com"
         primes = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53)
@@ -118,8 +117,7 @@ class HentainexusGalleryExtractor(GalleryExtractor):
 
         return result
 
-    @staticmethod
-    def _join_title(data):
+    def _join_title(self, data):
         event = data['event']
         artist = data['artist']
         circle = data['circle']

--- a/gallery_dl/extractor/hentainexus.py
+++ b/gallery_dl/extractor/hentainexus.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2024 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/hiperdex.py
+++ b/gallery_dl/extractor/hiperdex.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/hitomi.py
+++ b/gallery_dl/extractor/hitomi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/idolcomplex.py
+++ b/gallery_dl/extractor/idolcomplex.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/imagebam.py
+++ b/gallery_dl/extractor/imagebam.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/imagebam.py
+++ b/gallery_dl/extractor/imagebam.py
@@ -63,8 +63,7 @@ class ImagebamGalleryExtractor(ImagebamExtractor):
             image.update(data)
             yield Message.Url, image["url"], image
 
-    @staticmethod
-    def metadata(page):
+    def metadata(self, page):
         return {"title": text.unescape(text.extr(
             page, 'id="gallery-name">', '<').strip())}
 

--- a/gallery_dl/extractor/imagefap.py
+++ b/gallery_dl/extractor/imagefap.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/imagehosts.py
+++ b/gallery_dl/extractor/imagehosts.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/imgbox.py
+++ b/gallery_dl/extractor/imgbox.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/imgbox.py
+++ b/gallery_dl/extractor/imgbox.py
@@ -30,18 +30,15 @@ class ImgboxExtractor(Extractor):
                 text.nameext_from_url(imgdata["filename"], imgdata)
                 yield Message.Url, self.get_image_url(imgpage), imgdata
 
-    @staticmethod
-    def get_job_metadata():
+    def get_job_metadata(self):
         """Collect metadata for extractor-job"""
         return {}
 
-    @staticmethod
-    def get_image_keys():
+    def get_image_keys(self):
         """Return an iterable containing all image-keys"""
         return []
 
-    @staticmethod
-    def get_image_metadata(page):
+    def get_image_metadata(self, page):
         """Collect metadata for a downloadable file"""
         return text.extract_all(page, (
             ("num"      , '</a> &nbsp; ', ' of '),
@@ -49,8 +46,7 @@ class ImgboxExtractor(Extractor):
             ("filename" , ' title="', '"'),
         ))[0]
 
-    @staticmethod
-    def get_image_url(page):
+    def get_image_url(self, page):
         """Extract download-url"""
         return text.extr(page, 'property="og:image" content="', '"')
 
@@ -102,8 +98,7 @@ class ImgboxImageExtractor(ImgboxExtractor):
     def get_image_keys(self):
         return (self.image_key,)
 
-    @staticmethod
-    def get_image_metadata(page):
+    def get_image_metadata(self, page):
         data = ImgboxExtractor.get_image_metadata(page)
         if not data["filename"]:
             raise exception.NotFoundError("image")

--- a/gallery_dl/extractor/imgur.py
+++ b/gallery_dl/extractor/imgur.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2018-2020 Leonardo Taccari
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -357,8 +357,7 @@ class InstagramExtractor(Extractor):
 
         return data
 
-    @staticmethod
-    def _extract_tagged_users(src, dest):
+    def _extract_tagged_users(self, src, dest):
         dest["tagged_users"] = tagged_users = []
 
         edges = src.get("edge_media_to_tagged_user")
@@ -979,8 +978,7 @@ class InstagramGraphqlAPI():
         self.user_by_id = api.user_by_id
         self.user_id = api.user_id
 
-    @staticmethod
-    def _unsupported(_=None):
+    def _unsupported(self, _=None):
         raise exception.StopExtraction("Unsupported with GraphQL API")
 
     def highlights_tray(self, user_id):

--- a/gallery_dl/extractor/issuu.py
+++ b/gallery_dl/extractor/issuu.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/itaku.py
+++ b/gallery_dl/extractor/itaku.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/keenspot.py
+++ b/gallery_dl/extractor/keenspot.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/keenspot.py
+++ b/gallery_dl/extractor/keenspot.py
@@ -121,22 +121,18 @@ class KeenspotComicExtractor(Extractor):
         pos = page.index(self._needle) + len(self._needle)
         return text.extract(page, 'href="', '"', pos)[0]
 
-    @staticmethod
-    def _next_link(page):
+    def _next_link(self, page):
         return text.extr(page, '<link rel="next" href="', '"')
 
-    @staticmethod
-    def _next_id(page):
+    def _next_id(self, page):
         pos = page.find('id="next_')
         return text.rextr(page, 'href="', '"', pos) if pos >= 0 else None
 
-    @staticmethod
-    def _next_lastblood(page):
+    def _next_lastblood(self, page):
         pos = page.index("link rel='next'")
         return text.extract(page, "href='", "'", pos)[0]
 
-    @staticmethod
-    def _next_brawl(page):
+    def _next_brawl(self, page):
         pos = page.index("comic-nav-next")
         url = text.rextr(page, 'href="', '"', pos)
         return None if "?random" in url else url

--- a/gallery_dl/extractor/kemono.py
+++ b/gallery_dl/extractor/kemono.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/khinsider.py
+++ b/gallery_dl/extractor/khinsider.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/komikcast.py
+++ b/gallery_dl/extractor/komikcast.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/komikcast.py
+++ b/gallery_dl/extractor/komikcast.py
@@ -20,8 +20,7 @@ class KomikcastBase():
     category = "komikcast"
     root = "https://komikcast02.com"
 
-    @staticmethod
-    def parse_chapter_string(chapter_string, data=None):
+    def parse_chapter_string(self, chapter_string, data=None):
         """Parse 'chapter_string' value and add its info to 'data'"""
         if data is None:
             data = {}
@@ -52,8 +51,7 @@ class KomikcastChapterExtractor(KomikcastBase, ChapterExtractor):
         info = text.extr(page, "<title>", " - Komikcast<")
         return self.parse_chapter_string(info)
 
-    @staticmethod
-    def images(page):
+    def images(self, page):
         readerarea = text.extr(
             page, '<div class="main-reading-area', '</div')
         pattern = util.re(r"<img[^>]* src=[\"']([^\"']+)")
@@ -82,8 +80,7 @@ class KomikcastMangaExtractor(KomikcastBase, MangaExtractor):
             results.append((url, data.copy()))
         return results
 
-    @staticmethod
-    def metadata(page):
+    def metadata(self, page):
         """Return a dict with general metadata"""
         manga , pos = text.extract(page, "<title>" , " - Komikcast<")
         genres, pos = text.extract(

--- a/gallery_dl/extractor/lolisafe.py
+++ b/gallery_dl/extractor/lolisafe.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/mangadex.py
+++ b/gallery_dl/extractor/mangadex.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/mangafox.py
+++ b/gallery_dl/extractor/mangafox.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/mangahere.py
+++ b/gallery_dl/extractor/mangahere.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/mangapark.py
+++ b/gallery_dl/extractor/mangapark.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/mangaread.py
+++ b/gallery_dl/extractor/mangaread.py
@@ -15,8 +15,7 @@ class MangareadBase():
     category = "mangaread"
     root = "https://www.mangaread.org"
 
-    @staticmethod
-    def parse_chapter_string(chapter_string, data):
+    def parse_chapter_string(self, chapter_string, data):
         match = util.re(
             r"(?:(.+)\s*-\s*)?[Cc]hapter\s*(\d+)(\.\d+)?(?:\s*-\s*(.+))?"
         ).match(text.unescape(chapter_string).strip())

--- a/gallery_dl/extractor/mangoxo.py
+++ b/gallery_dl/extractor/mangoxo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/mangoxo.py
+++ b/gallery_dl/extractor/mangoxo.py
@@ -53,8 +53,7 @@ class MangoxoExtractor(Extractor):
             raise exception.AuthenticationError(data.get("msg"))
         return {"SESSION": self.cookies.get("SESSION")}
 
-    @staticmethod
-    def _sign_by_md5(username, password, token):
+    def _sign_by_md5(self, username, password, token):
         # https://dns.mangoxo.com/libs/plugins/phoenix-ui/js/phoenix-ui.js
         params = [
             ("username" , username),
@@ -68,8 +67,7 @@ class MangoxoExtractor(Extractor):
         params.append(("sign", sign.upper()))
         return params
 
-    @staticmethod
-    def _total_pages(page):
+    def _total_pages(self, page):
         return text.parse_int(text.extract(page, "total :", ",")[0])
 
 

--- a/gallery_dl/extractor/mastodon.py
+++ b/gallery_dl/extractor/mastodon.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/moebooru.py
+++ b/gallery_dl/extractor/moebooru.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/moebooru.py
+++ b/gallery_dl/extractor/moebooru.py
@@ -20,8 +20,7 @@ class MoebooruExtractor(BooruExtractor):
     filename_fmt = "{category}_{id}_{md5}.{extension}"
     page_start = 1
 
-    @staticmethod
-    def _prepare(post):
+    def _prepare(self, post):
         post["date"] = text.parse_timestamp(post["created_at"])
 
     def _html(self, post):

--- a/gallery_dl/extractor/motherless.py
+++ b/gallery_dl/extractor/motherless.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/myportfolio.py
+++ b/gallery_dl/extractor/myportfolio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/myportfolio.py
+++ b/gallery_dl/extractor/myportfolio.py
@@ -53,8 +53,7 @@ class MyportfolioGalleryExtractor(Extractor):
             for data["num"], url in enumerate(imgs, 1):
                 yield Message.Url, url, text.nameext_from_url(url, data)
 
-    @staticmethod
-    def metadata(page):
+    def metadata(self, page):
         """Collect general image metadata"""
         # og:title contains data as "<user> - <title>", but both
         # <user> and <title> can contain a "-" as well, so we get the title
@@ -81,8 +80,7 @@ class MyportfolioGalleryExtractor(Extractor):
             "description": text.unescape(descr),
         }
 
-    @staticmethod
-    def images(page):
+    def images(self, page):
         """Extract and return a list of all image-urls"""
         return (
             list(text.extract_iter(page, 'js-lightbox" data-src="', '"')) or

--- a/gallery_dl/extractor/naver.py
+++ b/gallery_dl/extractor/naver.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/naverwebtoon.py
+++ b/gallery_dl/extractor/naverwebtoon.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2021 Seonghyeon Cho
-# Copyright 2022-2033 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/naverwebtoon.py
+++ b/gallery_dl/extractor/naverwebtoon.py
@@ -54,8 +54,7 @@ class NaverwebtoonEpisodeExtractor(NaverwebtoonBase, GalleryExtractor):
                 extr('"painters":[', ']'), '"name":"', '"')]
         }
 
-    @staticmethod
-    def images(page):
+    def images(self, page):
         view_area = text.extr(page, 'id="comic_view_area"', '</div>')
         return [
             (url, None)

--- a/gallery_dl/extractor/newgrounds.py
+++ b/gallery_dl/extractor/newgrounds.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/newgrounds.py
+++ b/gallery_dl/extractor/newgrounds.py
@@ -260,8 +260,7 @@ class NewgroundsExtractor(Extractor):
             else:
                 yield {"image": url}
 
-    @staticmethod
-    def _extract_audio_data(extr, url):
+    def _extract_audio_data(self, extr, url):
         index = url.split("/")[5]
         return {
             "title"      : text.unescape(extr('"og:title" content="', '"')),
@@ -529,8 +528,7 @@ class NewgroundsFollowingExtractor(NewgroundsFavoriteExtractor):
         for url in self._pagination_favorites(kind, pnum):
             yield Message.Queue, url, data
 
-    @staticmethod
-    def _extract_favorites(page):
+    def _extract_favorites(self, page):
         return [
             text.ensure_http_scheme(user.rpartition('"')[2])
             for user in text.extract_iter(page, 'class="item-user', '"><img')

--- a/gallery_dl/extractor/nijie.py
+++ b/gallery_dl/extractor/nijie.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/nijie.py
+++ b/gallery_dl/extractor/nijie.py
@@ -73,8 +73,7 @@ class NijieExtractor(AsynchronousMixin, BaseExtractor):
     def image_ids(self):
         """Collect all relevant image-ids"""
 
-    @staticmethod
-    def _extract_data(page):
+    def _extract_data(self, page):
         """Extract image metadata from 'page'"""
         extr = text.extract_from(page)
         keywords = text.unescape(extr(
@@ -90,8 +89,7 @@ class NijieExtractor(AsynchronousMixin, BaseExtractor):
             "tags"       : keywords[2:-1],
         }
 
-    @staticmethod
-    def _extract_data_horne(page):
+    def _extract_data_horne(self, page):
         """Extract image metadata from 'page'"""
         extr = text.extract_from(page)
         keywords = text.unescape(extr(
@@ -124,8 +122,7 @@ class NijieExtractor(AsynchronousMixin, BaseExtractor):
             # do NOT use text.extr() here, as it doesn't support a pos argument
             return (text.extract(page, 'itemprop="image" src="', '"', pos)[0],)
 
-    @staticmethod
-    def _extract_user_name(page):
+    def _extract_user_name(self, page):
         return text.unescape(text.extr(page, "<br />", "<"))
 
     def login(self):
@@ -248,8 +245,7 @@ class NijieNuitaExtractor(NijieExtractor):
         data["user_name"] = self.user_name
         return data
 
-    @staticmethod
-    def _extract_user_name(page):
+    def _extract_user_name(self, page):
         return text.unescape(text.extr(page, "<title>", "さんの抜いた"))
 
 
@@ -262,8 +258,7 @@ class NijieFeedExtractor(NijieExtractor):
     def image_ids(self):
         return self._pagination("like_user_view")
 
-    @staticmethod
-    def _extract_user_name(page):
+    def _extract_user_name(self, page):
         return ""
 
 

--- a/gallery_dl/extractor/nozomi.py
+++ b/gallery_dl/extractor/nozomi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/nozomi.py
+++ b/gallery_dl/extractor/nozomi.py
@@ -98,8 +98,7 @@ class NozomiExtractor(Extractor):
     def metadata(self):
         return {}
 
-    @staticmethod
-    def _list(src):
+    def _list(self, src):
         return [x["tagname_display"] for x in src] if src else ()
 
 

--- a/gallery_dl/extractor/nsfwalbum.py
+++ b/gallery_dl/extractor/nsfwalbum.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/nsfwalbum.py
+++ b/gallery_dl/extractor/nsfwalbum.py
@@ -70,13 +70,11 @@ class NsfwalbumAlbumExtractor(GalleryExtractor):
                     self.root, image_id, spirit),),
             }
 
-    @staticmethod
-    def _validate_response(response):
+    def _validate_response(self, response):
         return not response.url.endswith(
             ("/no_image.jpg", "/placeholder.png", "/error.jpg"))
 
-    @staticmethod
-    def _annihilate(value, base=6):
+    def _annihilate(self, value, base=6):
         return "".join(
             chr(ord(char) ^ base)
             for char in value

--- a/gallery_dl/extractor/oauth.py
+++ b/gallery_dl/extractor/oauth.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/paheal.py
+++ b/gallery_dl/extractor/paheal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/paheal.py
+++ b/gallery_dl/extractor/paheal.py
@@ -108,8 +108,7 @@ class PahealTagExtractor(PahealExtractor):
                 return
             pnum += 1
 
-    @staticmethod
-    def _extract_data(post):
+    def _extract_data(self, post):
         pid , pos = text.extract(post, "", "'")
         data, pos = text.extract(post, "title='", "'", pos)
         md5 , pos = text.extract(post, "/_thumbs/", "/", pos)

--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -188,16 +188,14 @@ class PatreonExtractor(Extractor):
 
         return attr
 
-    @staticmethod
-    def _transform(included):
+    def _transform(self, included):
         """Transform 'included' into an easier to handle format"""
         result = collections.defaultdict(dict)
         for inc in included:
             result[inc["type"]][inc["id"]] = inc["attributes"]
         return result
 
-    @staticmethod
-    def _files(post, included, key):
+    def _files(self, post, included, key):
         """Build a list of files"""
         files = post["relationships"].get(key)
         if files and files.get("data"):
@@ -226,8 +224,7 @@ class PatreonExtractor(Extractor):
         cd = response.headers.get("Content-Disposition")
         return text.extr(cd, 'filename="', '"')
 
-    @staticmethod
-    def _filehash(url):
+    def _filehash(self, url):
         """Extract MD5 hash from a download URL"""
         parts = url.partition("?")[0].split("/")
         parts.reverse()
@@ -237,8 +234,7 @@ class PatreonExtractor(Extractor):
                 return part
         return ""
 
-    @staticmethod
-    def _build_url(endpoint, query):
+    def _build_url(self, endpoint, query):
         return (
             "https://www.patreon.com/api/" + endpoint +
 

--- a/gallery_dl/extractor/philomena.py
+++ b/gallery_dl/extractor/philomena.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/philomena.py
+++ b/gallery_dl/extractor/philomena.py
@@ -35,8 +35,7 @@ class PhilomenaExtractor(BooruExtractor):
             return url.rpartition(".")[0] + ".svg"
         return url
 
-    @staticmethod
-    def _prepare(post):
+    def _prepare(self, post):
         post["date"] = text.parse_datetime(
             post["created_at"][:19], "%Y-%m-%dT%H:%M:%S")
 

--- a/gallery_dl/extractor/pillowfort.py
+++ b/gallery_dl/extractor/pillowfort.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/pinterest.py
+++ b/gallery_dl/extractor/pinterest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/pinterest.py
+++ b/gallery_dl/extractor/pinterest.py
@@ -55,6 +55,15 @@ class PinterestExtractor(Extractor):
             pin.update(data)
             pin["count"] = len(files)
 
+            for key in (
+                "description",
+                "closeup_description",
+                "closeup_unified_description",
+            ):
+                value = pin.get(key)
+                if value:
+                    pin[key] = value.strip()
+
             yield Message.Directory, pin
             for pin["num"], file in enumerate(files, 1):
                 url = file["url"]

--- a/gallery_dl/extractor/pixeldrain.py
+++ b/gallery_dl/extractor/pixeldrain.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023-2024 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -336,8 +336,7 @@ class PixivExtractor(Extractor):
             if fmt in urls:
                 yield urls[fmt]
 
-    @staticmethod
-    def _date_from_url(url, offset=timedelta(hours=9)):
+    def _date_from_url(self, url, offset=timedelta(hours=9)):
         try:
             _, _, _, _, _, y, m, d, H, M, S, _ = url.split("/")
             return datetime(
@@ -345,8 +344,7 @@ class PixivExtractor(Extractor):
         except Exception:
             return None
 
-    @staticmethod
-    def _make_work(kind, url, user):
+    def _make_work(self, kind, url, user):
         p = url.split("/")
         return {
             "create_date"     : "{}-{}-{}T{}:{}:{}+09:00".format(

--- a/gallery_dl/extractor/plurk.py
+++ b/gallery_dl/extractor/plurk.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/plurk.py
+++ b/gallery_dl/extractor/plurk.py
@@ -28,8 +28,7 @@ class PlurkExtractor(Extractor):
     def plurks(self):
         """Return an iterable with all relevant 'plurk' objects"""
 
-    @staticmethod
-    def _urls(obj):
+    def _urls(self, obj):
         """Extract URLs from a 'plurk' object"""
         return text.extract_iter(obj["content"], ' href="', '"')
 
@@ -59,8 +58,7 @@ class PlurkExtractor(Extractor):
                 del data["count"]
             data["from_response_id"] = info["responses"][-1]["id"] + 1
 
-    @staticmethod
-    def _load(data):
+    def _load(self, data):
         if not data:
             raise exception.NotFoundError("user")
         return util.json_loads(

--- a/gallery_dl/extractor/pornhub.py
+++ b/gallery_dl/extractor/pornhub.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/pornpics.py
+++ b/gallery_dl/extractor/pornpics.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/readcomiconline.py
+++ b/gallery_dl/extractor/readcomiconline.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/realbooru.py
+++ b/gallery_dl/extractor/realbooru.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/recursive.py
+++ b/gallery_dl/extractor/recursive.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/reddit.py
+++ b/gallery_dl/extractor/reddit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/reddit.py
+++ b/gallery_dl/extractor/reddit.py
@@ -573,8 +573,7 @@ class RedditAPI():
         sid = self.extractor.config(key)
         return self._decode(sid.rpartition("_")[2].lower()) if sid else default
 
-    @staticmethod
-    def _decode(sid):
+    def _decode(self, sid):
         return util.bdecode(sid, "0123456789abcdefghijklmnopqrstuvwxyz")
 
 

--- a/gallery_dl/extractor/redgifs.py
+++ b/gallery_dl/extractor/redgifs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/rule34us.py
+++ b/gallery_dl/extractor/rule34us.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/rule34xyz.py
+++ b/gallery_dl/extractor/rule34xyz.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/saint.py
+++ b/gallery_dl/extractor/saint.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/sankaku.py
+++ b/gallery_dl/extractor/sankaku.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2023 Mike Fährmann
+# Copyright 2014-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/sankakucomplex.py
+++ b/gallery_dl/extractor/sankakucomplex.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/sankakucomplex.py
+++ b/gallery_dl/extractor/sankakucomplex.py
@@ -63,20 +63,17 @@ class SankakucomplexArticleExtractor(SankakucomplexExtractor):
             file.update(data)
             yield Message.Url, url, file
 
-    @staticmethod
-    def _extract_images(content):
+    def _extract_images(self, content):
         orig_sub = util.re(r"-\d+x\d+\.").sub
         return [
             orig_sub(".", url) for url in
             util.unique(text.extract_iter(content, 'data-lazy-src="', '"'))
         ]
 
-    @staticmethod
-    def _extract_videos(content):
+    def _extract_videos(self, content):
         return util.re(r"<source [^>]*src=[\"']([^\"']+)").findall(content)
 
-    @staticmethod
-    def _extract_embeds(content):
+    def _extract_embeds(self, content):
         return [
             "ytdl:" + url for url in
             util.re(r"<iframe [^>]*src=[\"']([^\"']+)").findall(content)

--- a/gallery_dl/extractor/schalenetwork.py
+++ b/gallery_dl/extractor/schalenetwork.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/scrolller.py
+++ b/gallery_dl/extractor/scrolller.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/seiga.py
+++ b/gallery_dl/extractor/seiga.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/sexcom.py
+++ b/gallery_dl/extractor/sexcom.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/shimmie2.py
+++ b/gallery_dl/extractor/shimmie2.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/slideshare.py
+++ b/gallery_dl/extractor/slideshare.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2016-2017 Leonardo Taccari
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/smugmug.py
+++ b/gallery_dl/extractor/smugmug.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/smugmug.py
+++ b/gallery_dl/extractor/smugmug.py
@@ -234,14 +234,12 @@ class SmugmugAPI(oauth.OAuth1API):
                 return
             params["start"] += params["count"]
 
-    @staticmethod
-    def _extend(endpoint, expands):
+    def _extend(self, endpoint, expands):
         if expands:
             endpoint += "?_expand=" + expands
         return endpoint
 
-    @staticmethod
-    def _apply_expansions(data, expands):
+    def _apply_expansions(self, data, expands):
 
         def unwrap(response):
             locator = response["Locator"]

--- a/gallery_dl/extractor/subscribestar.py
+++ b/gallery_dl/extractor/subscribestar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -58,8 +58,7 @@ class SzurubooruExtractor(booru.BooruExtractor):
             url = self.root + "/" + url
         return url
 
-    @staticmethod
-    def _prepare(post):
+    def _prepare(self, post):
         post["date"] = text.parse_datetime(
             post["creationTime"], "%Y-%m-%dT%H:%M:%S.%fZ")
 

--- a/gallery_dl/extractor/tapas.py
+++ b/gallery_dl/extractor/tapas.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/toyhouse.py
+++ b/gallery_dl/extractor/toyhouse.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/tsumino.py
+++ b/gallery_dl/extractor/tsumino.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/tsumino.py
+++ b/gallery_dl/extractor/tsumino.py
@@ -158,8 +158,7 @@ class TsuminoSearchExtractor(TsuminoBase, Extractor):
             raise exception.StopExtraction(
                 "Invalid search query '%s' (%s)", query, exc)
 
-    @staticmethod
-    def _parse_simple(query):
+    def _parse_simple(self, query):
         """Parse search query with format '?<key>=value>'"""
         key, _, value = query.partition("=")
         tag_types = {
@@ -179,8 +178,7 @@ class TsuminoSearchExtractor(TsuminoBase, Extractor):
             "Tags[0][Exclude]": "false",
         }
 
-    @staticmethod
-    def _parse_jsurl(data):
+    def _parse_jsurl(self, data):
         """Parse search query in JSURL format
 
         Nested lists and dicts are handled in a special way to deal

--- a/gallery_dl/extractor/tumblr.py
+++ b/gallery_dl/extractor/tumblr.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/tumblr.py
+++ b/gallery_dl/extractor/tumblr.py
@@ -198,14 +198,12 @@ class TumblrExtractor(Extractor):
                                  "', '".join(sorted(invalid)))
             return types
 
-    @staticmethod
-    def _prepare(url, post):
+    def _prepare(self, url, post):
         text.nameext_from_url(url, post)
         post["hash"] = post["filename"].partition("_")[2]
         return Message.Url, url, post
 
-    @staticmethod
-    def _prepare_image(url, post):
+    def _prepare_image(self, url, post):
         text.nameext_from_url(url, post)
 
         # try ".gifv" (#3095)
@@ -226,8 +224,7 @@ class TumblrExtractor(Extractor):
 
         return Message.Url, url, post
 
-    @staticmethod
-    def _prepare_avatar(url, post, blog):
+    def _prepare_avatar(self, url, post, blog):
         text.nameext_from_url(url, post)
         post["num"] = post["count"] = 1
         post["blog"] = blog
@@ -298,8 +295,7 @@ class TumblrPostExtractor(TumblrExtractor):
     def posts(self):
         return self.api.posts(self.blog, {"id": self.post_id})
 
-    @staticmethod
-    def _setup_posttypes():
+    def _setup_posttypes(self):
         return POST_TYPES
 
 

--- a/gallery_dl/extractor/tumblrgallery.py
+++ b/gallery_dl/extractor/tumblrgallery.py
@@ -20,13 +20,11 @@ class TumblrgalleryExtractor(GalleryExtractor):
     root = "https://tumblrgallery.xyz"
     referer = False
 
-    @staticmethod
-    def _urls_from_page(page):
+    def _urls_from_page(self, page):
         return text.extract_iter(
             page, '<div class="report"> <a class="xx-co-me" href="', '"')
 
-    @staticmethod
-    def _data_from_url(url):
+    def _data_from_url(self, url):
         filename = text.nameext_from_url(url)["filename"]
         parts = filename.split("_")
         try:

--- a/gallery_dl/extractor/twibooru.py
+++ b/gallery_dl/extractor/twibooru.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/twibooru.py
+++ b/gallery_dl/extractor/twibooru.py
@@ -36,8 +36,7 @@ class TwibooruExtractor(BooruExtractor):
             return post["view_url"].rpartition(".")[0] + ".svg"
         return post["view_url"]
 
-    @staticmethod
-    def _prepare(post):
+    def _prepare(self, post):
         post["date"] = text.parse_datetime(
             post["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ")
 

--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2016-2023 Mike Fährmann
+# Copyright 2016-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/unsplash.py
+++ b/gallery_dl/extractor/unsplash.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/unsplash.py
+++ b/gallery_dl/extractor/unsplash.py
@@ -48,8 +48,7 @@ class UnsplashExtractor(Extractor):
             yield Message.Directory, photo
             yield Message.Url, url, photo
 
-    @staticmethod
-    def metadata():
+    def metadata(self):
         return None
 
     def skip(self, num):

--- a/gallery_dl/extractor/vichan.py
+++ b/gallery_dl/extractor/vichan.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/vichan.py
+++ b/gallery_dl/extractor/vichan.py
@@ -73,8 +73,7 @@ class VichanThreadExtractor(VichanExtractor):
             self.root, post["board"], post["tim"], post["ext"])
         return Message.Url, post["url"], post
 
-    @staticmethod
-    def _process_8kun(post, data):
+    def _process_8kun(self, post, data):
         post.update(data)
         post["extension"] = post["ext"][1:]
 

--- a/gallery_dl/extractor/vipergirls.py
+++ b/gallery_dl/extractor/vipergirls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/vk.py
+++ b/gallery_dl/extractor/vk.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/vsco.py
+++ b/gallery_dl/extractor/vsco.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/vsco.py
+++ b/gallery_dl/extractor/vsco.py
@@ -109,8 +109,7 @@ class VscoExtractor(Extractor):
                 yield from medias
                 params["page"] += 1
 
-    @staticmethod
-    def _transform_media(media):
+    def _transform_media(self, media):
         if "responsiveUrl" not in media:
             return None
         media["_id"] = media["id"]
@@ -122,8 +121,7 @@ class VscoExtractor(Extractor):
         media["image_meta"] = media.get("imageMeta")
         return media
 
-    @staticmethod
-    def _transform_video(media):
+    def _transform_video(self, media):
         media["is_video"] = True
         media["grid_name"] = ""
         media["video_url"] = media["playback_url"]

--- a/gallery_dl/extractor/wallhaven.py
+++ b/gallery_dl/extractor/wallhaven.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/wallhaven.py
+++ b/gallery_dl/extractor/wallhaven.py
@@ -39,8 +39,7 @@ class WallhavenExtractor(Extractor):
         """Return general metadata"""
         return ()
 
-    @staticmethod
-    def _transform(wp):
+    def _transform(self, wp):
         wp["url"] = wp.pop("path")
         if "tags" in wp:
             wp["tags"] = [t["name"] for t in wp["tags"]]

--- a/gallery_dl/extractor/wallpapercave.py
+++ b/gallery_dl/extractor/wallpapercave.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2021 David Hoppenbrouwers
-# Copyright 2023 Mike Fährmann
+# Copyright 2023-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -20,8 +20,7 @@ class WeasylExtractor(Extractor):
     root = "https://www.weasyl.com"
     useragent = util.USERAGENT
 
-    @staticmethod
-    def populate_submission(data):
+    def populate_submission(self, data):
         # Some submissions don't have content and can be skipped
         if "submission" in data["media"]:
             data["url"] = data["media"]["submission"][0]["url"]

--- a/gallery_dl/extractor/webtoons.py
+++ b/gallery_dl/extractor/webtoons.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2020 Leonardo Taccari
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/weibo.py
+++ b/gallery_dl/extractor/weibo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/wikimedia.py
+++ b/gallery_dl/extractor/wikimedia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2022 Ailothaen
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/wikimedia.py
+++ b/gallery_dl/extractor/wikimedia.py
@@ -52,8 +52,7 @@ class WikimediaExtractor(BaseExtractor):
                 return url
         raise exception.StopExtraction("Unable to find API endpoint")
 
-    @staticmethod
-    def prepare(image):
+    def prepare(self, image):
         """Adjust the content of an image object"""
         image["metadata"] = {
             m["name"]: m["value"]

--- a/gallery_dl/extractor/xhamster.py
+++ b/gallery_dl/extractor/xhamster.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/xvideos.py
+++ b/gallery_dl/extractor/xvideos.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/ytdl.py
+++ b/gallery_dl/extractor/ytdl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/extractor/zerochan.py
+++ b/gallery_dl/extractor/zerochan.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/formatter.py
+++ b/gallery_dl/formatter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/formatter.py
+++ b/gallery_dl/formatter.py
@@ -463,8 +463,7 @@ class Literal():
     # __getattr__, __getattribute__, and __class_getitem__
     # are all slower than regular __getitem__
 
-    @staticmethod
-    def __getitem__(key):
+    def __getitem__(self, key):
         return key
 
 

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -682,8 +682,7 @@ class DownloadJob(Job):
             for hook, callback in hooks.items():
                 self.hooks[hook].append(callback)
 
-    @staticmethod
-    def _call_hook(callback, condition, pathfmt):
+    def _call_hook(self, callback, condition, pathfmt):
         if condition(pathfmt.kwdict):
             callback(pathfmt)
 
@@ -818,12 +817,10 @@ class UrlJob(Job):
         if depth >= self.maxdepth:
             self.handle_queue = self.handle_url
 
-    @staticmethod
-    def handle_url(url, _):
+    def handle_url(self, url, _):
         stdout_write(url + "\n")
 
-    @staticmethod
-    def handle_url_fallback(url, kwdict):
+    def handle_url_fallback(self, url, kwdict):
         stdout_write(url + "\n")
         if "_fallback" in kwdict:
             for url in kwdict["_fallback"]:

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/output.py
+++ b/gallery_dl/output.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/output.py
+++ b/gallery_dl/output.py
@@ -483,8 +483,7 @@ class CustomOutput():
         self._fmt_progress_total = (options.get("progress-total") or
                                     "\r{3:>3}% {0:>7}B {1:>7}B/s ").format
 
-    @staticmethod
-    def _make_func(shorten, format_string, limit):
+    def _make_func(self, shorten, format_string, limit):
         fmt = format_string.format
         return lambda txt: fmt(shorten(txt, limit, CHAR_ELLIPSIES))
 

--- a/gallery_dl/path.py
+++ b/gallery_dl/path.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/path.py
+++ b/gallery_dl/path.py
@@ -183,8 +183,7 @@ class PathFormat():
             return self.check_file()
         return False
 
-    @staticmethod
-    def check_file():
+    def check_file(self):
         return True
 
     def _enum_file(self):

--- a/gallery_dl/postprocessor/__init__.py
+++ b/gallery_dl/postprocessor/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/postprocessor/compare.py
+++ b/gallery_dl/postprocessor/compare.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2023 Mike Fährmann
+# Copyright 2020-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/postprocessor/compare.py
+++ b/gallery_dl/postprocessor/compare.py
@@ -62,12 +62,10 @@ class ComparePP(PostProcessor):
     def _compare(self, f1, f2):
         return self._compare_size(f1, f2) and self._compare_content(f1, f2)
 
-    @staticmethod
-    def _compare_size(f1, f2):
+    def _compare_size(self, f1, f2):
         return os.stat(f1).st_size == os.stat(f2).st_size
 
-    @staticmethod
-    def _compare_content(f1, f2):
+    def _compare_content(self, f1, f2):
         size = 16384
         with open(f1, "rb") as fp1, open(f2, "rb") as fp2:
             while True:

--- a/gallery_dl/postprocessor/metadata.py
+++ b/gallery_dl/postprocessor/metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/postprocessor/metadata.py
+++ b/gallery_dl/postprocessor/metadata.py
@@ -268,8 +268,7 @@ class MetadataPP(PostProcessor):
         if not private:
             return util.filter_dict
 
-    @staticmethod
-    def _make_encoder(options, indent=None):
+    def _make_encoder(self, options, indent=None):
         return json.JSONEncoder(
             ensure_ascii=options.get("ascii", False),
             sort_keys=options.get("sort", False),

--- a/gallery_dl/postprocessor/ugoira.py
+++ b/gallery_dl/postprocessor/ugoira.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/postprocessor/ugoira.py
+++ b/gallery_dl/postprocessor/ugoira.py
@@ -425,15 +425,13 @@ class UgoiraPP(PostProcessor):
 
         return (None, None)
 
-    @staticmethod
-    def _delay_gcd(frames):
+    def _delay_gcd(self, frames):
         result = frames[0]["delay"]
         for f in frames:
             result = gcd(result, f["delay"])
         return result
 
-    @staticmethod
-    def _delay_is_uniform(frames):
+    def _delay_is_uniform(self, frames):
         delay = frames[0]["delay"]
         for f in frames:
             if f["delay"] != delay:

--- a/gallery_dl/update.py
+++ b/gallery_dl/update.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2024 Mike Fährmann
+# Copyright 2024-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -684,8 +684,7 @@ class CustomNone():
     def __call__(self, *args, **kwargs):
         return self
 
-    @staticmethod
-    def __next__():
+    def __next__(self):
         raise StopIteration
 
     def __eq__(self, other):
@@ -733,20 +732,17 @@ class CustomNone():
     __abs__ = identity
     __invert__ = identity
 
-    @staticmethod
-    def __len__():
+    def __len__(self):
         return 0
 
     __int__ = __len__
     __hash__ = __len__
     __index__ = __len__
 
-    @staticmethod
-    def __format__(_):
+    def __format__(self, _):
         return "None"
 
-    @staticmethod
-    def __str__():
+    def __str__(self):
         return "None"
 
     __repr__ = __str__
@@ -1052,8 +1048,7 @@ class RangePredicate():
                 return True
         return False
 
-    @staticmethod
-    def _parse(rangespec):
+    def _parse(self, rangespec):
         """Parse an integer range string and return the resulting ranges
 
         Examples:

--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -8,7 +8,7 @@
 
 """Utility functions and classes"""
 
-import re
+import re as re_module
 import os
 import sys
 import json
@@ -28,9 +28,9 @@ from email.utils import mktime_tz, parsedate_tz
 from . import text, version, exception
 
 try:
-    re_compile = re._compiler.compile
+    re_compile = re_module._compiler.compile
 except AttributeError:
-    re_compile = re.sre_compile.compile
+    re_compile = re_module.sre_compile.compile
 
 CACHE_PATTERN = {}
 
@@ -791,7 +791,7 @@ GLOBALS = {
     "hash_sha1": sha1,
     "hash_md5" : md5,
     "std"      : ModuleProxy(),
-    "re"       : re,
+    "re"       : re_module,
     "exts_image"  : EXTS_IMAGE,
     "exts_video"  : EXTS_VIDEO,
     "exts_archive": EXTS_ARCHIVE,

--- a/gallery_dl/ytdl.py
+++ b/gallery_dl/ytdl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/results/agnph.py
+++ b/test/results/agnph.py
@@ -21,7 +21,7 @@ __tests__ = (
     "#category": ("booru", "agnph", "post"),
     "#class"   : agnph.AgnphPostExtractor,
     "#options" : {"tags": True},
-    "#urls"        : "http://agn.ph/gallery/data/7d/a5/7da50021f3e86f6cf1c215652060d772.png",
+    "#results"     : "http://agn.ph/gallery/data/7d/a5/7da50021f3e86f6cf1c215652060d772.png",
     "#sha1_content": "93c8b2d3f53e891ad8fa68d5f60f8c7a70acd836",
 
     "artist"      : "reyn_goldfur",

--- a/test/results/aibooru.py
+++ b/test/results/aibooru.py
@@ -41,7 +41,7 @@ __tests__ = (
     "#category": ("Danbooru", "aibooru", "post"),
     "#class"   : danbooru.DanbooruPostExtractor,
     "#options" : {"ugoira": True},
-    "#urls"    : "https://cdn.aibooru.download/original/f9/6b/f96b2b3254884ab527fab0a7e9c39ba9.zip",
+    "#results" : "https://cdn.aibooru.download/original/f9/6b/f96b2b3254884ab527fab0a7e9c39ba9.zip",
 
     "_ugoira_original"     : False,
     "_ugoira_frame_data[*]": {

--- a/test/results/ao3.py
+++ b/test/results/ao3.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"     : "https://archiveofourown.org/works/47802076",
     "#class"   : ao3.Ao3WorkExtractor,
-    "#urls"    : "https://archiveofourown.org/downloads/47802076/The_Wildcard.pdf?updated_at=1720398424",
+    "#results" : "https://archiveofourown.org/downloads/47802076/The_Wildcard.pdf?updated_at=1720398424",
 
     "author"   : "Flowers_for_ghouls",
     "bookmarks": range(100, 300),
@@ -127,7 +127,7 @@ __tests__ = (
     "#url"     : "https://archiveofourown.org/works/47802076",
     "#class"   : ao3.Ao3WorkExtractor,
     "#options" : {"formats": ["epub", "mobi", "azw3", "pdf", "html"]},
-    "#urls"    : (
+    "#results" : (
         "https://archiveofourown.org/downloads/47802076/The_Wildcard.epub?updated_at=1720398424",
         "https://archiveofourown.org/downloads/47802076/The_Wildcard.mobi?updated_at=1720398424",
         "https://archiveofourown.org/downloads/47802076/The_Wildcard.azw3?updated_at=1720398424",
@@ -141,13 +141,13 @@ __tests__ = (
     "#comment" : "restricted work / login required",
     "#class"   : ao3.Ao3WorkExtractor,
     "#auth"    : True,
-    "#urls"    : "https://archiveofourown.org/downloads/12345/Unquenchable.pdf?updated_at=1716029699",
+    "#results" : "https://archiveofourown.org/downloads/12345/Unquenchable.pdf?updated_at=1716029699",
 },
 
 {
     "#url"     : "https://archiveofourown.org/series/1903930",
     "#class"   : ao3.Ao3SeriesExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://archiveofourown.org/works/26131546",
         "https://archiveofourown.org/works/26291101",
         "https://archiveofourown.org/works/26325292",
@@ -173,7 +173,7 @@ __tests__ = (
 {
     "#url"     : "https://archiveofourown.org/users/Fyrelass",
     "#class"   : ao3.Ao3UserExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://archiveofourown.org/users/Fyrelass/works",
         "https://archiveofourown.org/users/Fyrelass/series",
     ),
@@ -205,7 +205,7 @@ __tests__ = (
     "#url"     : "https://archiveofourown.org/users/Fyrelass/works",
     "#class"   : ao3.Ao3UserWorksExtractor,
     "#auth"    : False,
-    "#urls"    : (
+    "#results" : (
         "https://archiveofourown.org/works/55035061",
         "https://archiveofourown.org/works/58979287",
         "https://archiveofourown.org/works/52704457",
@@ -224,7 +224,7 @@ __tests__ = (
     "#url"     : "https://archiveofourown.org/users/Fyrelass/series",
     "#class"   : ao3.Ao3UserSeriesExtractor,
     "#auth"    : False,
-    "#urls"    : (
+    "#results" : (
         "https://archiveofourown.org/series/3821575",
     ),
 },

--- a/test/results/arcalive.py
+++ b/test/results/arcalive.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"    : "https://arca.live/b/arknights/66031722?p=1",
     "#class"  : arcalive.ArcalivePostExtractor,
-    "#urls"   : "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig",
+    "#results": "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig",
 
     "isEditable": False,
     "isDeletable": False,
@@ -60,14 +60,14 @@ __tests__ = (
     "#url"    : "https://arca.live/b/breaking/66031722",
     "#comment": "/b/breaking page URL",
     "#class"  : arcalive.ArcalivePostExtractor,
-    "#urls"   : "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig",
+    "#results": "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig",
 },
 
 {
     "#url"    : "https://arca.live/b/bluearchive/65031202",
     "#comment": "animated gif",
     "#class"  : arcalive.ArcalivePostExtractor,
-    "#urls"   : (
+    "#results": (
         "https://ac.namu.la/20221211sac/5ea7fbca5e49ec16beb099fc6fc991690d37552e599b1de8462533908346241e.png?type=orig",
         "https://ac.namu.la/20221211sac/7f73beefc4f18a2f986bc4c6821caba706e27f4c94cb828fc16e2af1253402d9.gif?type=orig",
         "https://ac.namu.la/20221211sac2/3e72f9e05ca97c0c3c0fe5f25632b06eb21ab9f211e9ea22816e16468ee241ca.png?type=orig",
@@ -78,7 +78,7 @@ __tests__ = (
     "#url"    : "https://arca.live/b/arknights/122263340",
     "#comment": "animated webp",
     "#class"  : arcalive.ArcalivePostExtractor,
-    "#urls"   : (
+    "#results": (
         "https://ac.namu.la/20241126sac/b2175d9ef4504945d3d989526120dbb6aded501ddedfba8ecc44a64e7aae9059.gif?type=orig",
         "https://ac.namu.la/20241126sac/bc1f3cb388a3a2d099ab67bc09b28f0a93c2c4755152b3ef9190690a9f0a28fb.webp?type=orig",
     ),
@@ -89,7 +89,7 @@ __tests__ = (
     "#comment": ".mp4 video",
     "#class"  : arcalive.ArcalivePostExtractor,
     "#options": {"gifs": "check"},
-    "#urls"   : "https://ac.namu.la/20240926sac/16f07778a97f91b935c8a3394ead01a223d96b2a619fdb25c4628ddba88b5fad.mp4?type=orig",
+    "#results": "https://ac.namu.la/20240926sac/16f07778a97f91b935c8a3394ead01a223d96b2a619fdb25c4628ddba88b5fad.mp4?type=orig",
 },
 
 {
@@ -97,7 +97,7 @@ __tests__ = (
     "#comment": "fake .mp4 GIF",
     "#class"  : arcalive.ArcalivePostExtractor,
     "#options": {"gifs": True},
-    "#urls"   : "https://ac.namu.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b.gif?type=orig",
+    "#results": "https://ac.namu.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b.gif?type=orig",
 
     "_fallback": ("https://ac.namu.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b.mp4?type=orig",),
 },
@@ -107,14 +107,14 @@ __tests__ = (
     "#comment": "fake .mp4 GIF",
     "#class"  : arcalive.ArcalivePostExtractor,
     "#options": {"gifs": False},
-    "#urls"   : "https://ac.namu.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b.mp4?type=orig",
+    "#results": "https://ac.namu.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b.mp4?type=orig",
 },
 
 {
     "#url"    : "https://arca.live/b/arknights/49406926",
     "#comment": "static emoticon",
     "#class"  : arcalive.ArcalivePostExtractor,
-    "#urls"   : "https://ac.namu.la/20220428sac2/41f472adcea674aff75f15f146e81c27032bc4d6c8073bd7c19325bd1c97d335.png?type=orig",
+    "#results": "https://ac.namu.la/20220428sac2/41f472adcea674aff75f15f146e81c27032bc4d6c8073bd7c19325bd1c97d335.png?type=orig",
 },
 
 {
@@ -122,7 +122,7 @@ __tests__ = (
     "#comment": "animated emoticon",
     "#class"  : arcalive.ArcalivePostExtractor,
     "#options": {"emoticons": True},
-    "#urls"   : (
+    "#results": (
         "https://ac.namu.la/20221123sac2/14925c5e22ab9f17f2923ae60a39b7af0794c43e478ecaba054ab6131e57e022.png?type=orig",
         "https://ac.namu.la/20221123sac2/50c385a4004bca44271a2f6133990f086cfefd29a7968514e9c14d6017d61265.png?type=orig",
         "https://ac.namu.la/20221005sac2/28ebe073fffbb2b88f710c2d380b0fe6dd99a856070c4a836db57634a5371366.gif?type=orig",
@@ -156,7 +156,7 @@ __tests__ = (
     "#url"  : "https://arca.live/u/@Si%EB%A6%AC%EB%A7%81",
     "#class": arcalive.ArcaliveUserExtractor,
     "#range": "1-5",
-    "#urls" : (
+    "#results": (
         "https://arca.live/b/vrchat/107257886",
         "https://arca.live/b/soulworkers/95371697",
         "https://arca.live/b/arcalivebreverse/90843346",

--- a/test/results/archivedmoe.py
+++ b/test/results/archivedmoe.py
@@ -28,7 +28,7 @@ __tests__ = (
     "#comment" : "broken thebarchive .webm URLs (#5116)",
     "#category": ("foolfuuka", "archivedmoe", "thread"),
     "#class"   : foolfuuka.FoolfuukaThreadExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://thebarchive.com/b/full_image/1705625299234839.gif",
         "https://thebarchive.com/b/full_image/1705625431133806.web",
         "https://thebarchive.com/b/full_image/1705626190307840.web",
@@ -40,7 +40,7 @@ __tests__ = (
     "#comment" : "filename/timestamp fixup for redirect URL (#7652)",
     "#category": ("foolfuuka", "archivedmoe", "thread"),
     "#class"   : foolfuuka.FoolfuukaThreadExtractor,
-    "#urls"    : (
+    "#results" : (
         "http://desuarchive.org/a/full_image/1749537017533.jpg",
     ),
 },

--- a/test/results/artstation.py
+++ b/test/results/artstation.py
@@ -87,7 +87,7 @@ __tests__ = (
     "#url"     : "https://www.artstation.com/mikf/collections",
     "#category": ("", "artstation", "collections"),
     "#class"   : artstation.ArtstationCollectionsExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://www.artstation.com/mikf/collections/2647023",
         "https://www.artstation.com/mikf/collections/2647719",
     ),
@@ -163,7 +163,7 @@ __tests__ = (
     "#class"   : artstation.ArtstationImageExtractor,
     "#options" : {"videos": True},
     "#range"   : "2-3",
-    "#urls"    : (
+    "#results" : (
         "https://cdn.artstation.com/p/video_sources/000/819/843/infection-4.mp4",
         "https://cdn.artstation.com/p/video_sources/000/819/725/infection-veinonly-2.mp4",
     ),

--- a/test/results/b4k.py
+++ b/test/results/b4k.py
@@ -12,14 +12,14 @@ __tests__ = (
     "#url"     : "https://arch.b4k.dev/meta/thread/196/",
     "#category": ("foolfuuka", "b4k", "thread"),
     "#class"   : foolfuuka.FoolfuukaThreadExtractor,
-    "#urls"    : "https://arch.b4k.dev/media/meta/image/1481/33/14813348737492.jpg",
+    "#results" : "https://arch.b4k.dev/media/meta/image/1481/33/14813348737492.jpg",
 },
 
 {
     "#url"     : "https://arch.b4k.co/meta/thread/196/",
     "#category": ("foolfuuka", "b4k", "thread"),
     "#class"   : foolfuuka.FoolfuukaThreadExtractor,
-    "#urls"    : "https://arch.b4k.dev/media/meta/image/1481/33/14813348737492.jpg",
+    "#results" : "https://arch.b4k.dev/media/meta/image/1481/33/14813348737492.jpg",
 },
 
 {

--- a/test/results/batoto.py
+++ b/test/results/batoto.py
@@ -142,7 +142,7 @@ __tests__ = (
     "#category": ("", "batoto", "manga"),
     "#class"   : batoto.BatotoMangaExtractor,
     "#log"     : "'UPLOADER NOTICE - The comic was deleted off EbookRenta :/'",
-    "#urls"    : (
+    "#results" : (
         "https://mto.to/title/136193-botsuraku-sunzen-desunode-konyakusha-o-furikiro-to-omoimasu-official/2456573-ch_1",
         "https://mto.to/title/136193-botsuraku-sunzen-desunode-konyakusha-o-furikiro-to-omoimasu-official/2713985-ch_2",
         "https://mto.to/title/136193-botsuraku-sunzen-desunode-konyakusha-o-furikiro-to-omoimasu-official/2739046-ch_3",

--- a/test/results/behance.py
+++ b/test/results/behance.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#url"     : "https://www.behance.net/gallery/17386197/A-Short-Story",
     "#category": ("", "behance", "gallery"),
     "#class"   : behance.BehanceGalleryExtractor,
-    "#urls"    : (
+    "#results" : (
         "ytdl:https://player.vimeo.com/video/97189640?title=0&byline=0&portrait=0&color=ffffff",
         "https://mir-s3-cdn-cf.behance.net/project_modules/source/a5a12417386197.562bc055a107d.jpg",
     ),
@@ -69,7 +69,7 @@ __tests__ = (
     "#category": ("", "behance", "gallery"),
     "#class"   : behance.BehanceGalleryExtractor,
     "#options" : {"modules": "text"},
-    "#urls"    : """text:<div>Make Shift<br><a href="https://www.moevir.com/News/make-shif?fbclid=IwAR2MXL7mVDskdXHitLs4tv_RQFqB1tpAYix2EMIzea4lOSIPdPOR45wEJMA" target="_blank" rel="nofollow">https://www.moevir.com/News/make-shif</a><br>Moevir Magazine November Issue 2019<br>Photography by Caesar Lima @caephoto <br>Model: Bee @phamhuongbee <br>Makeup by Monica Alvarez @monicaalvarezmakeup <br>Styling by Jessica Boal @jessicaboal <br>Hair by James Gilbert @brandnewjames<br>Shot at Vila Sophia<br></div>""",
+    "#results" : """text:<div>Make Shift<br><a href="https://www.moevir.com/News/make-shif?fbclid=IwAR2MXL7mVDskdXHitLs4tv_RQFqB1tpAYix2EMIzea4lOSIPdPOR45wEJMA" target="_blank" rel="nofollow">https://www.moevir.com/News/make-shif</a><br>Moevir Magazine November Issue 2019<br>Photography by Caesar Lima @caephoto <br>Model: Bee @phamhuongbee <br>Makeup by Monica Alvarez @monicaalvarezmakeup <br>Styling by Jessica Boal @jessicaboal <br>Hair by James Gilbert @brandnewjames<br>Shot at Vila Sophia<br></div>""",
 },
 
 {

--- a/test/results/bilibili.py
+++ b/test/results/bilibili.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"  : "https://www.bilibili.com/opus/988425412565532689",
     "#class": bilibili.BilibiliArticleExtractor,
-    "#urls" : (
+    "#results": (
         "http://i0.hdslb.com/bfs/new_dyn/311264c4dcf45261f7d7a7fe451b05b9405279279.png",
         "http://i0.hdslb.com/bfs/new_dyn/b60d8bc6996529613d617443a12c0a93405279279.png",
         "http://i0.hdslb.com/bfs/new_dyn/d4494543210d9eee5310e11dc62581e4405279279.png",
@@ -39,7 +39,7 @@ __tests__ = (
     "#url"    : "https://www.bilibili.com/opus/977981688469520405",
     "#comment": "'module_top' file (#6687)",
     "#class"  : bilibili.BilibiliArticleExtractor,
-    "#urls"   : (
+    "#results": (
         "http://i0.hdslb.com/bfs/new_dyn/c74018e8272c56a6c28a1a1dc3c586311242656443.jpg",
     ),
 

--- a/test/results/blogspot.py
+++ b/test/results/blogspot.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://julianbphotography.blogspot.com/2010/12/moon-rise.html",
     "#category": ("blogger", "blogspot", "post"),
     "#class"   : blogger.BloggerPostExtractor,
-    "#urls"    : "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjH9WkPvLJq2moxKtyt3ieJZWSDFQwOi3PHRdlHVHEQHRwy-d86Jg6HWSMhxaa6EgvlXq-zDMmKM4kIPn27eJ9Hepk2X9e9HQhqwMfrT8RYTnFe65uexw7KSk5FdWHxRVp5crz3p_qph3Bj/s0/Icy-Moonrise---For-Web.jpg",
+    "#results" : "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjH9WkPvLJq2moxKtyt3ieJZWSDFQwOi3PHRdlHVHEQHRwy-d86Jg6HWSMhxaa6EgvlXq-zDMmKM4kIPn27eJ9Hepk2X9e9HQhqwMfrT8RYTnFe65uexw7KSk5FdWHxRVp5crz3p_qph3Bj/s0/Icy-Moonrise---For-Web.jpg",
 
     "blog": {
         "date"       : "dt:2010-11-21 18:19:42",

--- a/test/results/bluesky.py
+++ b/test/results/bluesky.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/bsky.app",
     "#category": ("", "bluesky", "user"),
     "#class"   : bluesky.BlueskyUserExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://bsky.app/profile/bsky.app/media",
     ),
 },
@@ -32,7 +32,7 @@ __tests__ = (
     "#category": ("", "bluesky", "user"),
     "#class"   : bluesky.BlueskyUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : (
+    "#results" : (
         "https://bsky.app/profile/did:plc:z72i7hdynmk6r22z27h6tvur/info",
         "https://bsky.app/profile/did:plc:z72i7hdynmk6r22z27h6tvur/avatar",
         "https://bsky.app/profile/did:plc:z72i7hdynmk6r22z27h6tvur/banner",
@@ -48,7 +48,7 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/bsky.app",
     "#class"   : bluesky.BlueskyUserExtractor,
     "#options" : {"quoted": True},
-    "#urls"    : "https://bsky.app/profile/bsky.app/posts",
+    "#results" : "https://bsky.app/profile/bsky.app/posts",
 },
 
 {
@@ -60,14 +60,14 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/bsky.app/avatar",
     "#category": ("", "bluesky", "avatar"),
     "#class"   : bluesky.BlueskyAvatarExtractor,
-    "#urls"    : "https://puffball.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z72i7hdynmk6r22z27h6tvur&cid=bafkreihagr2cmvl2jt4mgx3sppwe2it3fwolkrbtjrhcnwjk4jdijhsoze",
+    "#results" : "https://puffball.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z72i7hdynmk6r22z27h6tvur&cid=bafkreihagr2cmvl2jt4mgx3sppwe2it3fwolkrbtjrhcnwjk4jdijhsoze",
 },
 
 {
     "#url"     : "https://bsky.app/profile/did:plc:z72i7hdynmk6r22z27h6tvur/banner",
     "#category": ("", "bluesky", "background"),
     "#class"   : bluesky.BlueskyBackgroundExtractor,
-    "#urls"    : "https://puffball.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z72i7hdynmk6r22z27h6tvur&cid=bafkreichzyovokfzmymz36p5jibbjrhsur6n7hjnzxrpbt5jaydp2szvna",
+    "#results" : "https://puffball.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z72i7hdynmk6r22z27h6tvur&cid=bafkreichzyovokfzmymz36p5jibbjrhsur6n7hjnzxrpbt5jaydp2szvna",
 },
 
 {
@@ -98,7 +98,7 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/mikf.bsky.social/video",
     "#category": ("", "bluesky", "video"),
     "#class"   : bluesky.BlueskyVideoExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreibmoobktxndnzauku65onoxu2tvvqswetezv76tqcwipktjs3cw3m",
         "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreihq2nsfocrnlpx4nykb4szouqszxwmy3ucnk4k46nx5t6hjnxlti4",
     ),
@@ -117,7 +117,7 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/bsky.app/follows",
     "#category": ("", "bluesky", "following"),
     "#class"   : bluesky.BlueskyFollowingExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://bsky.app/profile/did:plc:eon2iu7v3x2ukgxkqaf7e5np",
         "https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz",
     ),
@@ -136,7 +136,7 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/mikf.bsky.social/likes",
     "#class"   : bluesky.BlueskyLikesExtractor,
     "#auth"    : False,
-    "#urls"    : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreih2dn2xeyoayabgvpyutv5ldubcdxzfqipijasfzxyeez7fff5ymi",
+    "#results" : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreih2dn2xeyoayabgvpyutv5ldubcdxzfqipijasfzxyeez7fff5ymi",
 },
 
 {
@@ -144,7 +144,7 @@ __tests__ = (
     "#class"   : bluesky.BlueskyLikesExtractor,
     "#options" : {"endpoint": "getActorLikes"},
     "#auth"    : True,
-    "#urls"    : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreih2dn2xeyoayabgvpyutv5ldubcdxzfqipijasfzxyeez7fff5ymi",
+    "#results" : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreih2dn2xeyoayabgvpyutv5ldubcdxzfqipijasfzxyeez7fff5ymi",
 },
 
 {
@@ -191,7 +191,7 @@ __tests__ = (
     "#category": ("", "bluesky", "post"),
     "#class"   : bluesky.BlueskyPostExtractor,
     "#options"     : {"metadata": True},
-    "#urls"        : "https://puffball.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z72i7hdynmk6r22z27h6tvur&cid=bafkreidypzoaybmfj5h7pnpiyct6ng5yae6ydp4czrm72ocg7ev6vbirri",
+    "#results"     : "https://puffball.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:z72i7hdynmk6r22z27h6tvur&cid=bafkreidypzoaybmfj5h7pnpiyct6ng5yae6ydp4czrm72ocg7ev6vbirri",
     "#sha1_content": "ffcf25e7c511173a12de5276b85903309fcd8d14",
 
     "author": {
@@ -244,7 +244,7 @@ __tests__ = (
     "#category": ("", "bluesky", "post"),
     "#class"   : bluesky.BlueskyPostExtractor,
     "#options"     : {"metadata": "facets"},
-    "#urls"        : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreib7ydpe3xxo4cq7nn32w7eqhcanfaanz6caepd2z4kzplxtx2ctgi",
+    "#results"     : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreib7ydpe3xxo4cq7nn32w7eqhcanfaanz6caepd2z4kzplxtx2ctgi",
     "#sha1_content": "9cf5748f6d00aae83fbb3cc2c6eb3caa832b90f4",
 
     "author": {
@@ -288,7 +288,7 @@ __tests__ = (
     "#comment" : "different embed CID path",
     "#category": ("", "bluesky", "post"),
     "#class"   : bluesky.BlueskyPostExtractor,
-    "#urls"    : "https://amanita.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:owc2r2dsewj3hk73rtd746zh&cid=bafkreieuhplc7fpbvi3suvacaf2dqxzvuu4hgl5o6eifqb76tf3uopldmi",
+    "#results" : "https://amanita.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:owc2r2dsewj3hk73rtd746zh&cid=bafkreieuhplc7fpbvi3suvacaf2dqxzvuu4hgl5o6eifqb76tf3uopldmi",
 },
 
 {
@@ -296,7 +296,7 @@ __tests__ = (
     "#comment" : "video (#6183)",
     "#category": ("", "bluesky", "post"),
     "#class"   : bluesky.BlueskyPostExtractor,
-    "#urls"    : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreihq2nsfocrnlpx4nykb4szouqszxwmy3ucnk4k46nx5t6hjnxlti4",
+    "#results" : "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreihq2nsfocrnlpx4nykb4szouqszxwmy3ucnk4k46nx5t6hjnxlti4",
 
     "description": "kirby and reimu dance",
     "text"       : "video",
@@ -311,7 +311,7 @@ __tests__ = (
     "#comment" : "quote (#6183)",
     "#class"   : bluesky.BlueskyPostExtractor,
     "#options" : {"quoted": True},
-    "#urls"    : "https://lionsmane.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:eyhmjdxsnthqhvvszdejaocz&cid=bafkreib6eb7tfozksquveaj3z5msyx3hkniubrulxdys3eftthvmuzrtme",
+    "#results" : "https://lionsmane.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:eyhmjdxsnthqhvvszdejaocz&cid=bafkreib6eb7tfozksquveaj3z5msyx3hkniubrulxdys3eftthvmuzrtme",
 
     "author": {
         "associated" : dict,
@@ -339,7 +339,7 @@ __tests__ = (
     "#comment" : "quote with media (#6183)",
     "#class"   : bluesky.BlueskyPostExtractor,
     "#options" : {"quoted": True},
-    "#urls"    : (
+    "#results" : (
         "https://conocybe.us-west.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:cslxjqkeexku6elp5xowxkq7&cid=bafkreiegcyremdrecmnpisci3a3nduc7lm3zdcl76z5o5rd4nstyolrxki",
         "https://lionsmane.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:eyhmjdxsnthqhvvszdejaocz&cid=bafkreicojrnwiw5eqo3ko2q6duduyjaoyiqvdc25kuikcedlijtbgvlt5e",
 
@@ -396,7 +396,7 @@ __tests__ = (
     "#url"     : "https://bsky.app/profile/alt.bun.how/post/3l7rdfxhyds2f",
     "#comment" : "non-bsky PDS (#6406)",
     "#class"   : bluesky.BlueskyPostExtractor,
-    "#urls"        : "https://pds.bun.how/xrpc/com.atproto.sync.getBlob?did=did:plc:7x6rtuenkuvxq3zsvffp2ide&cid=bafkreielhgekjheckgjusx7x5hxkbrqryfdmzdwwp2zoxchovgnpzkxzae",
+    "#results"     : "https://pds.bun.how/xrpc/com.atproto.sync.getBlob?did=did:plc:7x6rtuenkuvxq3zsvffp2ide&cid=bafkreielhgekjheckgjusx7x5hxkbrqryfdmzdwwp2zoxchovgnpzkxzae",
     "#sha1_content": "1777956de0dc8cf0815c5c7eb574a24ce54a1d42",
 
     "author": {

--- a/test/results/boosty.py
+++ b/test/results/boosty.py
@@ -18,7 +18,7 @@ __tests__ = (
 {
     "#url"     : "https://boosty.to/milshoo?postsFrom=1706742000&postsTo=1709247599",
     "#class"   : boosty.BoostyUserExtractor,
-    "#urls"    : "https://images.boosty.to/image/ff0d2006-3ee7-483d-a5fc-2a05b531742c?change_time=1707829201",
+    "#results" : "https://images.boosty.to/image/ff0d2006-3ee7-483d-a5fc-2a05b531742c?change_time=1707829201",
 },
 
 {
@@ -31,7 +31,7 @@ __tests__ = (
 {
     "#url"     : "https://boosty.to/milshoo/posts/4304d8f0-3f49-4f97-a3f3-9f064bc32b2f",
     "#class"   : boosty.BoostyPostExtractor,
-    "#urls"    : "https://images.boosty.to/image/75f86086-fc67-4ed2-9365-2958d3d1a8f7?change_time=1711027786",
+    "#results" : "https://images.boosty.to/image/75f86086-fc67-4ed2-9365-2958d3d1a8f7?change_time=1711027786",
 
     "count"    : 1,
     "num"      : 1,

--- a/test/results/bunkr.py
+++ b/test/results/bunkr.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://bunkr.sk/a/Lktg9Keq",
     "#category": ("lolisafe", "bunkr", "album"),
     "#class"   : bunkr.BunkrAlbumExtractor,
-    "#urls"        : "https://brg-bk.cdn.gigachad-cdn.ru/test-%E3%83%86%E3%82%B9%E3%83%88-%22%26%3E-QjgneIQv.png?n=test-%E3%83%86%E3%82%B9%E3%83%88-%22%26%3E.png",
+    "#results"     : "https://brg-bk.cdn.gigachad-cdn.ru/test-%E3%83%86%E3%82%B9%E3%83%88-%22%26%3E-QjgneIQv.png?n=test-%E3%83%86%E3%82%B9%E3%83%88-%22%26%3E.png",
     "#sha1_content": "0c8768055e4e20e7c7259608b67799171b691140",
 
     "album_id"   : "Lktg9Keq",
@@ -32,7 +32,7 @@ __tests__ = (
     "#url"     : "https://bunkr.is/a/iXTTc1o2",
     "#category": ("lolisafe", "bunkr", "album"),
     "#class"   : bunkr.BunkrAlbumExtractor,
-    "#urls"        : (
+    "#results"     : (
         "https://mlk-bk.cdn.gigachad-cdn.ru/image-sZrQUeOx.jpg?n=image.jpg",
     ),
     "#sha1_content": "55998743751dfe008d0e95605114fcbfa7dc4de8",
@@ -195,7 +195,7 @@ __tests__ = (
     "#url"     : "https://bunkr.black/i/image-sZrQUeOx.jpg",
     "#category": ("lolisafe", "bunkr", "media"),
     "#class"   : bunkr.BunkrMediaExtractor,
-    "#urls"        : "https://mlk-bk.cdn.gigachad-cdn.ru/image-sZrQUeOx.jpg?n=image.jpg",
+    "#results"     : "https://mlk-bk.cdn.gigachad-cdn.ru/image-sZrQUeOx.jpg?n=image.jpg",
     "#sha1_content": "55998743751dfe008d0e95605114fcbfa7dc4de8",
 
     "count"    : 1,
@@ -211,14 +211,14 @@ __tests__ = (
     "#comment" : "/f/ URL",
     "#category": ("lolisafe", "bunkr", "media"),
     "#class"   : bunkr.BunkrMediaExtractor,
-    "#urls"    : "https://mlk-bk.cdn.gigachad-cdn.ru/image-sZrQUeOx.jpg?n=image.jpg",
+    "#results" : "https://mlk-bk.cdn.gigachad-cdn.ru/image-sZrQUeOx.jpg?n=image.jpg",
 },
 
 {
     "#url"     : "https://bunkrrr.org/d/dJuETSzKLrUps",
     "#category": ("lolisafe", "bunkr", "media"),
     "#class"   : bunkr.BunkrMediaExtractor,
-    "#urls"        : "https://brg-bk.cdn.gigachad-cdn.ru/file-r5fmwjdd.zip?n=file.zip",
+    "#results"     : "https://brg-bk.cdn.gigachad-cdn.ru/file-r5fmwjdd.zip?n=file.zip",
     "#sha1_content": "102ddd7894fe39b3843098fc51f972a0af938f45",
 
     "count"    : 1,
@@ -235,7 +235,7 @@ __tests__ = (
     "#comment" : "redirect to '/f/rEeTUL8MXR17A' (#6790)",
     "#category": ("lolisafe", "bunkr", "media"),
     "#class"   : bunkr.BunkrMediaExtractor,
-    "#urls"    : "https://meatballs.bunkr.ru/27-03-2024-Rp-0FfrropA.mp4",
+    "#results" : "https://meatballs.bunkr.ru/27-03-2024-Rp-0FfrropA.mp4",
 },
 
 {
@@ -243,7 +243,7 @@ __tests__ = (
     "#comment" : "correct 'name' from HTML (#6790)",
     "#category": ("lolisafe", "bunkr", "media"),
     "#class"   : bunkr.BunkrMediaExtractor,
-    "#urls"    : "https://kebab.bunkr.ru/80ca5405-8b8d-4f9f-8167-8b046bb9dc67.mp4",
+    "#results" : "https://kebab.bunkr.ru/80ca5405-8b8d-4f9f-8167-8b046bb9dc67.mp4",
 
     "id"       : "",
     "id_url"   : "wYGCKbGhSvuAW",
@@ -257,7 +257,7 @@ __tests__ = (
     "#comment" : "file gone --- 403 error for main 'brg-bk.cdn.gigachad-cdn.ru' URL (#6732 #6972)",
     "#category": ("lolisafe", "bunkr", "media"),
     "#class"   : bunkr.BunkrMediaExtractor,
-    "#urls"        : "https://brg-bk.cdn.gigachad-cdn.ru/IMG_47272f2c698d257fd22f4300ae98ec35929b-iEYVkLPQ.jpg?n=IMG_47272f2c698d257fd22f4300ae98ec35929b.jpg",
+    "#results"     : "https://brg-bk.cdn.gigachad-cdn.ru/IMG_47272f2c698d257fd22f4300ae98ec35929b-iEYVkLPQ.jpg?n=IMG_47272f2c698d257fd22f4300ae98ec35929b.jpg",
     "#sha1_content": "f1c839743563828b250e48d485933a735a508527",
 
     "_fallback": (

--- a/test/results/civitai.py
+++ b/test/results/civitai.py
@@ -12,7 +12,7 @@ __tests__ = (
 {
     "#url"  : "https://civitai.com/models/703211/maid-classic",
     "#class": civitai.CivitaiModelExtractor,
-    "#urls" : [
+    "#results": (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/51ea6a54-762c-46cf-9588-726461193c96/original=true/00019-2944604798.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/aaa474a8-5a4d-4003-819f-79df2935ad78/original=true/00020-1919126538.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1bb22783-1c29-405e-9d7e-7c98b5a53d65/original=true/00021-2415646212.png",
@@ -22,7 +22,7 @@ __tests__ = (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5c4efa68-bb58-47c5-a716-98cd0f51f047/original=true/00013-4238863814.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/69bf3279-df2c-4ec8-b795-479e9cd3db1b/original=true/00014-3150861441.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2dd1dc69-45a6-4beb-b36b-2e2bc65e3cda/original=true/00015-2885514572.png",
-    ],
+    ),
 
     "model"  : {
         "description": "<p>The strength of Lora is recommended to be around 1.0.</p>",
@@ -47,11 +47,11 @@ __tests__ = (
     "#url"    : "https://civitai.com/models/703211?modelVersionId=786644",
     "#comment": "model version ID",
     "#class"  : civitai.CivitaiModelExtractor,
-    "#urls"   : [
+    "#results": (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/52b6efa7-801c-4901-90b4-fa3964d23480/original=true/00004-822988489.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c4d3bcd5-0e23-4f4e-9f34-d13b2f2bf14c/original=true/00005-1059918744.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/68568d22-c4f3-45cb-ac32-82f1cedf968f/original=true/00006-3467286319.png",
-    ],
+    ),
 
     "version": {
         "baseModel"   : "Pony",
@@ -81,7 +81,7 @@ __tests__ = (
     "#url"  : "https://civitai.com/images/26962948",
     "#class": civitai.CivitaiImageExtractor,
     "#options"     : {"quality": "w", "metadata": True},
-    "#urls"        : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/69bf3279-df2c-4ec8-b795-479e9cd3db1b/w/00014-3150861441.png",
+    "#results"     : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/69bf3279-df2c-4ec8-b795-479e9cd3db1b/w/00014-3150861441.png",
     "#sha1_content": "a9a9d08f5fcdbc1e1eec7f203717f9df97b7a671",
 
     "createdAt": "2024-08-31T01:11:47.021Z",
@@ -193,7 +193,7 @@ __tests__ = (
     "#url"    : "https://civitai.com/images/44789630",
     "#comment": "video",
     "#class"  : civitai.CivitaiImageExtractor,
-    "#urls"   : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6a09ec54-6de4-4af1-b11d-2d0d8a66d651/quality=100/copy_C6C532CE-EC47-4A52-9138-AEF1D7756F16.Mp4",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6a09ec54-6de4-4af1-b11d-2d0d8a66d651/quality=100/copy_C6C532CE-EC47-4A52-9138-AEF1D7756F16.Mp4",
 
     "date"     : "dt:2024-12-10 19:19:14",
     "extension": "mp4",
@@ -226,7 +226,7 @@ __tests__ = (
     "#url"  : "https://civitai.com/images/74353746",
     "#comment": "video, rated 'R', WebP download (#7502)",
     "#class": civitai.CivitaiImageExtractor,
-    "#urls" : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c7e3744b-8f0d-4124-94c1-75e2af00431d/quality=100/2025-04-25-23h40m21s_seed665048144_A man appears from off screen and spanks her butto_2.webm",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c7e3744b-8f0d-4124-94c1-75e2af00431d/quality=100/2025-04-25-23h40m21s_seed665048144_A man appears from off screen and spanks her butto_2.webm",
 
     "date"     : "dt:2025-05-05 12:27:28",
     "extension": "webm",
@@ -262,7 +262,7 @@ __tests__ = (
     "#comment": "no 'modelVersionId' (#7432)",
     "#class"  : civitai.CivitaiImageExtractor,
     "#options": {"metadata": "version"},
-    "#urls"   : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/65c1a01c-2583-4495-b4e9-bdb94218004e/original=true/5b5b95f8-9923-4c27-b50a-c801c0311375-0.jpg",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/65c1a01c-2583-4495-b4e9-bdb94218004e/original=true/5b5b95f8-9923-4c27-b50a-c801c0311375-0.jpg",
 
     "model"  : None,
     "version": None,
@@ -272,7 +272,7 @@ __tests__ = (
     "#url"    : "https://civitai.com/images/68947296",
     "#comment": "rated R / nsfwlevel 4",
     "#class"  : civitai.CivitaiImageExtractor,
-    "#urls"   : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2d1fbe1b-6038-479f-8c37-39d338198fb1/quality=100/received_687641707052140.mp4",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/2d1fbe1b-6038-479f-8c37-39d338198fb1/quality=100/received_687641707052140.mp4",
 
     "nsfwLevel": 4,
 },
@@ -281,7 +281,7 @@ __tests__ = (
     "#url"    : "https://civitai.com/images/68852050",
     "#comment": "rated X / nsfwlevel 8",
     "#class"  : civitai.CivitaiImageExtractor,
-    "#urls"   : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1107208c-14cc-46fd-848d-2efa14fa6180/original=true/QRQC7HE5DFW3QZ85R3MXQXY440.jpeg",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/1107208c-14cc-46fd-848d-2efa14fa6180/original=true/QRQC7HE5DFW3QZ85R3MXQXY440.jpeg",
 
     "nsfwLevel": 8,
 },
@@ -290,7 +290,7 @@ __tests__ = (
     "#url"    : "https://civitai.com/images/68851932",
     "#comment": "rated XXX / nsfwlevel 16",
     "#class"  : civitai.CivitaiImageExtractor,
-    "#urls"   : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fdbaa27d-4278-496b-8209-21591e5dc6fe/original=true/Q8AE16QCMCYCCBX49PG8VVWWD0.jpeg",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/fdbaa27d-4278-496b-8209-21591e5dc6fe/original=true/Q8AE16QCMCYCCBX49PG8VVWWD0.jpeg",
 
     "nsfwLevel": 16,
 },
@@ -299,11 +299,11 @@ __tests__ = (
     "#url"    : "https://civitai.com/posts/6877551",
     "#class"  : civitai.CivitaiPostExtractor,
     "#options": {"metadata": "generation"},
-    "#urls"   : [
+    "#results": (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6220fa0f-9037-4b1d-bfbd-a740a06eeb7c/original=true/30748752.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cd1edb7f-7b50-4da5-bf23-d38f24d8aef0/original=true/30748747.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/cfd5b231-accd-49bd-8bde-370880f63aa6/original=true/30748733.png",
-    ],
+    ),
 
     "post": {
         "id"  : 6877551,
@@ -359,7 +359,7 @@ __tests__ = (
 {
     "#url"  : "https://civitai.com/search/models?sortBy=models_v9&query=Voynich",
     "#class": civitai.CivitaiSearchModelsExtractor,
-    "#urls" : (
+    "#results": (
         "https://civitai.com/models/99868",
         "https://civitai.com/models/341330",
         "https://civitai.com/models/884509",
@@ -378,10 +378,10 @@ __tests__ = (
 {
     "#url"  : "https://civitai.com/user/waomodder",
     "#class": civitai.CivitaiUserExtractor,
-    "#urls" : [
+    "#results": (
         "https://civitai.com/user/waomodder/models",
         "https://civitai.com/user/waomodder/posts",
-    ],
+    ),
 },
 
 {
@@ -395,7 +395,7 @@ __tests__ = (
     "#url"    : "https://civitai.com/user/waomodder/models?tag=character&types=Checkpoint&types=TextualInversion&types=Hypernetwork&types=LORA&checkpointType=Trained&fileFormats=SafeTensor&fileFormats=PickleTensor",
     "#comment": "various filters (#7138)",
     "#class"  : civitai.CivitaiUserModelsExtractor,
-    "#urls"   : (
+    "#results": (
         "https://civitai.com/models/42166",
         "https://civitai.com/models/79845",
         "https://civitai.com/models/81424",
@@ -425,7 +425,7 @@ __tests__ = (
     "#url"    : "https://civitai.com/user/waomodder/images?tags=5132",
     "#comment": "tags (#7138)",
     "#class"  : civitai.CivitaiUserImagesExtractor,
-    "#urls"   : "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8cc7c513-ba77-4444-a21f-7e3907d29a4e/original=true/982824.png",
+    "#results": "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/8cc7c513-ba77-4444-a21f-7e3907d29a4e/original=true/982824.png",
 },
 
 {
@@ -433,7 +433,7 @@ __tests__ = (
     "#comment": "various filters (#7138)",
     "#class"  : civitai.CivitaiUserImagesExtractor,
     "#range"  : "1-3",
-    "#urls"   : (
+    "#results": (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/c44c116a-263b-457d-8fa8-cc3d7716a0aa/original=true/36800924.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0f6cf303-8b12-4401-914e-bff33371e9c6/original=true/36801099.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/9a682316-e451-4b98-8873-cc6c2e2d39bb/original=true/36801079.png",
@@ -445,7 +445,7 @@ __tests__ = (
     "#category": ("", "civitai", "reactions-images"),
     "#class"   : civitai.CivitaiUserImagesExtractor,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/dd29c97a-1e95-4186-8df5-632736cbae79/original=true/00012-2489035818.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/5c4efa68-bb58-47c5-a716-98cd0f51f047/original=true/00013-4238863814.png",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/69bf3279-df2c-4ec8-b795-479e9cd3db1b/original=true/00014-3150861441.png",
@@ -473,7 +473,7 @@ __tests__ = (
     "#category": ("", "civitai", "reactions-videos"),
     "#class"   : civitai.CivitaiUserVideosExtractor,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/6a09ec54-6de4-4af1-b11d-2d0d8a66d651/quality=100/copy_C6C532CE-EC47-4A52-9138-AEF1D7756F16.Mp4",
         "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/74cd3e71-7833-4e32-9724-b8d1702693be/quality=100/1_THANKSGIVING_CLAYMATION_TOPAZ.mp4",
     ),

--- a/test/results/coomer.py
+++ b/test/results/coomer.py
@@ -13,14 +13,14 @@ __tests__ = (
     "#comment" : "coomer (#2100)",
     "#category": ("", "coomer", "onlyfans"),
     "#class"   : kemono.KemonoPostExtractor,
-    "#urls"    : "https://coomer.su/data/7d/3f/7d3fd9804583dc224968c0591163ec91794552b04f00a6c2f42a15b68231d5a8.jpg",
+    "#results" : "https://coomer.su/data/7d/3f/7d3fd9804583dc224968c0591163ec91794552b04f00a6c2f42a15b68231d5a8.jpg",
 },
 
 {
     "#url"     : "https://coomer.party/onlyfans/user/alinity/post/125962203",
     "#category": ("", "coomer", "onlyfans"),
     "#class"   : kemono.KemonoPostExtractor,
-    "#urls"    : "https://coomer.party/data/7d/3f/7d3fd9804583dc224968c0591163ec91794552b04f00a6c2f42a15b68231d5a8.jpg",
+    "#results" : "https://coomer.party/data/7d/3f/7d3fd9804583dc224968c0591163ec91794552b04f00a6c2f42a15b68231d5a8.jpg",
 },
 
 )

--- a/test/results/danbooru.py
+++ b/test/results/danbooru.py
@@ -62,7 +62,7 @@ __tests__ = (
     "#class"   : danbooru.DanbooruPoolExtractor,
     "#auth"    : False,
     "#sha1_content": "15226ba183579bc2cdd67260445b5c97959a3e82",
-    "#urls"        : (
+    "#results"     : (
         "https://cdn.donmai.us/original/d8/3d/d83df4af8c0fa6d6069f8d3cf0b7dd56.jpg",
         "https://cdn.donmai.us/original/70/82/7082572fa74650f3c1f39152550cd724.jpg",
         "https://cdn.donmai.us/original/7a/b5/7ab551d011b89155a743d81308de653a.jpg",
@@ -92,7 +92,7 @@ __tests__ = (
     "#category": ("Danbooru", "danbooru", "pool"),
     "#class"   : danbooru.DanbooruPoolExtractor,
     "#options" : {"order-posts": "asc"},
-    "#urls"    : (
+    "#results" : (
         "https://cdn.donmai.us/original/c5/7b/c57b045fee282199277d0f94e298b9dc.jpg",
         "https://cdn.donmai.us/original/44/6d/446d8b5db9b78694936408049745ee42.jpg",
         "https://cdn.donmai.us/original/34/0c/340c721ceb7fce6892a234adf0bea811.jpg",
@@ -105,7 +105,7 @@ __tests__ = (
     "#category": ("Danbooru", "danbooru", "pool"),
     "#class"   : danbooru.DanbooruPoolExtractor,
     "#options" : {"order-posts": "pool_desc"},
-    "#urls"    : (
+    "#results" : (
         "https://cdn.donmai.us/original/30/3b/303bdefb719b54253aa7731cf11ef91f.jpg",
         "https://cdn.donmai.us/original/47/c2/47c2c1ba1f7b83e0a487dbc7e722059f.jpg",
         "https://cdn.donmai.us/original/34/0c/340c721ceb7fce6892a234adf0bea811.jpg",
@@ -118,7 +118,7 @@ __tests__ = (
     "#category": ("Danbooru", "danbooru", "pool"),
     "#class"   : danbooru.DanbooruPoolExtractor,
     "#options" : {"order-posts": "id"},
-    "#urls"    : (
+    "#results" : (
         "https://cdn.donmai.us/original/30/3b/303bdefb719b54253aa7731cf11ef91f.jpg",
         "https://cdn.donmai.us/original/44/6d/446d8b5db9b78694936408049745ee42.jpg",
         "https://cdn.donmai.us/original/34/0c/340c721ceb7fce6892a234adf0bea811.jpg",
@@ -131,7 +131,7 @@ __tests__ = (
     "#category": ("Danbooru", "danbooru", "pool"),
     "#class"   : danbooru.DanbooruPoolExtractor,
     "#options" : {"order-posts": "asc_id"},
-    "#urls"    : (
+    "#results" : (
         "https://cdn.donmai.us/original/c5/7b/c57b045fee282199277d0f94e298b9dc.jpg",
         "https://cdn.donmai.us/original/47/c2/47c2c1ba1f7b83e0a487dbc7e722059f.jpg",
         "https://cdn.donmai.us/original/34/0c/340c721ceb7fce6892a234adf0bea811.jpg",
@@ -306,7 +306,7 @@ __tests__ = (
     "#category": ("Danbooru", "danbooru", "post"),
     "#class"   : danbooru.DanbooruPostExtractor,
     "#options" : {"ugoira": False},
-    "#urls"    : "https://cdn.donmai.us/sample/5e/e5/sample-5ee54a2d95ed36376ec1d8f6ddbdece9.webm",
+    "#results" : "https://cdn.donmai.us/sample/5e/e5/sample-5ee54a2d95ed36376ec1d8f6ddbdece9.webm",
 
     "!_ugoira_original"  : ...,
     "!_ugoira_frame_data": ...,
@@ -317,7 +317,7 @@ __tests__ = (
     "#category": ("Danbooru", "danbooru", "post"),
     "#class"   : danbooru.DanbooruPostExtractor,
     "#options" : {"ugoira": True},
-    "#urls"    : "https://cdn.donmai.us/original/5e/e5/5ee54a2d95ed36376ec1d8f6ddbdece9.zip",
+    "#results" : "https://cdn.donmai.us/original/5e/e5/5ee54a2d95ed36376ec1d8f6ddbdece9.zip",
 
     "_ugoira_original"     : False,
     "_ugoira_frame_data[*]": {
@@ -350,7 +350,7 @@ __tests__ = (
     "#url"     : "https://danbooru.donmai.us/artists/288683",
     "#category": ("Danbooru", "danbooru", "artist"),
     "#class"   : danbooru.DanbooruArtistExtractor,
-    "#urls"    : "https://danbooru.donmai.us/posts?tags=kaori_%28vuoian_appxv%29",
+    "#results" : "https://danbooru.donmai.us/posts?tags=kaori_%28vuoian_appxv%29",
 
     "created_at" : "2022-05-12T16:00:40.852-04:00",
     "updated_at" : "2022-05-12T22:10:51.917-04:00",

--- a/test/results/derpibooru.py
+++ b/test/results/derpibooru.py
@@ -60,7 +60,7 @@ __tests__ = (
     "#comment" : "svg (#5643)",
     "#category": ("philomena", "derpibooru", "post"),
     "#class"   : philomena.PhilomenaPostExtractor,
-    "#urls"        : "https://derpicdn.net/img/view/2024/4/1/3334658.svg",
+    "#results"     : "https://derpicdn.net/img/view/2024/4/1/3334658.svg",
     "#sha1_content": "eec5adf02e2a4fe83b9211c0444d57dc03e21f50",
 
     "extension": "svg",

--- a/test/results/deviantart.py
+++ b/test/results/deviantart.py
@@ -14,7 +14,7 @@ __tests__ = (
     "#url"     : "https://www.deviantart.com/shimoda7",
     "#category": ("", "deviantart", "user"),
     "#class"   : deviantart.DeviantartUserExtractor,
-    "#urls"    : "https://www.deviantart.com/shimoda7/gallery",
+    "#results" : "https://www.deviantart.com/shimoda7/gallery",
 },
 
 {
@@ -22,7 +22,7 @@ __tests__ = (
     "#category": ("", "deviantart", "user"),
     "#class"   : deviantart.DeviantartUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : (
+    "#results" : (
         "https://www.deviantart.com/shimoda7/avatar",
         "https://www.deviantart.com/shimoda7/banner",
         "https://www.deviantart.com/shimoda7/gallery",
@@ -210,7 +210,7 @@ __tests__ = (
     "#url"     : "https://deviantart.com/shimoda7/avatar",
     "#category": ("", "deviantart", "avatar"),
     "#class"   : deviantart.DeviantartAvatarExtractor,
-    "#urls"        : "https://a.deviantart.net/avatars-big/s/h/shimoda7.jpg?4",
+    "#results"     : "https://a.deviantart.net/avatars-big/s/h/shimoda7.jpg?4",
     "#sha1_content": "abf2cc79b842315f2e54bfdd93bf794a0f612b6f",
 
     "author"         : {
@@ -248,7 +248,7 @@ __tests__ = (
     "#class"   : deviantart.DeviantartAvatarExtractor,
     "#archive" : False,
     "#options" : {"formats": ["original.jpg", "big.jpg", "big.png", "big.gif"]},
-    "#urls"    : (
+    "#results" : (
         "https://a.deviantart.net/avatars-original/s/h/shimoda7.jpg?4",
         "https://a.deviantart.net/avatars-big/s/h/shimoda7.jpg?4",
         "https://a.deviantart.net/avatars-big/s/h/shimoda7.png?4",
@@ -805,7 +805,7 @@ __tests__ = (
     "#comment" : "wixmp URL rewrite /intermediary/",
     "#category": ("", "deviantart", "deviation"),
     "#class"   : deviantart.DeviantartDeviationExtractor,
-    "#urls"    : "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/intermediary/f/4deb0f1a-cdef-444e-b194-c8d6b3f7e933/dd1xca2-7f835e62-6fd3-4b99-92c7-2bfd4e1b296f.jpg",
+    "#results" : "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/intermediary/f/4deb0f1a-cdef-444e-b194-c8d6b3f7e933/dd1xca2-7f835e62-6fd3-4b99-92c7-2bfd4e1b296f.jpg",
 
     "is_downloadable": False,
     "is_original"    : False,

--- a/test/results/directlink.py
+++ b/test/results/directlink.py
@@ -31,7 +31,7 @@ __tests__ = (
     "#comment" : "empty path",
     "#category": ("", "directlink", "example.org"),
     "#class"   : directlink.DirectlinkExtractor,
-    "#urls"    : "https://example.org/file.webm",
+    "#results" : "https://example.org/file.webm",
 
     "domain"   : "example.org",
     "path"     : "",
@@ -44,7 +44,7 @@ __tests__ = (
     "#comment" : "more complex example",
     "#category": ("", "directlink", "example.org"),
     "#class"   : directlink.DirectlinkExtractor,
-    "#urls"    : "https://example.org/path/to/file.webm?que=1?&ry=2/#fragment",
+    "#results" : "https://example.org/path/to/file.webm?que=1?&ry=2/#fragment",
 
     "domain"   : "example.org",
     "path"     : "path/to",
@@ -59,7 +59,7 @@ __tests__ = (
     "#comment" : "percent-encoded characters",
     "#category": ("", "directlink", "example.org"),
     "#class"   : directlink.DirectlinkExtractor,
-    "#urls"    : "https://example.org/%27%3C%23/%23%3E%27.jpg?key=%3C%26%3E",
+    "#results" : "https://example.org/%27%3C%23/%23%3E%27.jpg?key=%3C%26%3E",
 
     "domain"   : "example.org",
     "path"     : "'<#",
@@ -81,7 +81,7 @@ __tests__ = (
     "#comment" : "internationalized domain name",
     "#category": ("", "directlink", "josefsson.org"),
     "#class"   : directlink.DirectlinkExtractor,
-    "#urls"    : "https://räksmörgås.josefsson.org/raksmorgas.jpg",
+    "#results" : "https://räksmörgås.josefsson.org/raksmorgas.jpg",
 
     "domain"   : "räksmörgås.josefsson.org",
     "path"     : "",

--- a/test/results/dynastyscans.py
+++ b/test/results/dynastyscans.py
@@ -38,7 +38,7 @@ __tests__ = (
     "#class"   : dynastyscans.DynastyscansSearchExtractor,
 
     "#sha1_metadata": "67690b4e21f59746f112803cba4c4d81fcbb9dbd",
-    "#urls"         : (
+    "#results"      : (
         "https://dynasty-scans.com/system/images_images/000/032/932/full/66051624_p0.webp",
         "https://dynasty-scans.com/system/images_images/000/021/368/full/KEIGI_32-1467964487873486851-img1.webp",
         "https://dynasty-scans.com/system/images_images/000/004/596/full/tortoise.webp",
@@ -88,7 +88,7 @@ __tests__ = (
 {
     "#url"     : "https://dynasty-scans.com/anthologies/aashi_to_watashi_gyaru_yuri_anthology",
     "#class"   : dynastyscans.DynastyscansAnthologyExtractor,
-    "#urls"    : "https://dynasty-scans.com/chapters/dont_call_me_senpai",
+    "#results" : "https://dynasty-scans.com/chapters/dont_call_me_senpai",
 
     "!alert"        : (),
     "!description"  : """<p><a href="https://dynasty-scans.com/anthologies/aashi_to_watashi_gyaru_yuri_anthology_volume_2">Volume 2</a></p>""",

--- a/test/results/e621.py
+++ b/test/results/e621.py
@@ -151,14 +151,14 @@ __tests__ = (
     "#url"     : "https://e621.cc/?tags=rating:safe",
     "#category": ("E621", "e621", "frontend"),
     "#class"   : e621.E621FrontendExtractor,
-    "#urls"    : "https://e621.net/posts?tags=rating:safe",
+    "#results" : "https://e621.net/posts?tags=rating:safe",
 },
 
 {
     "#url"     : "https://e621.anthro.fr/?q=rating:safe",
     "#category": ("E621", "e621", "frontend"),
     "#class"   : e621.E621FrontendExtractor,
-    "#urls"    : "https://e621.net/posts?tags=rating:safe",
+    "#results" : "https://e621.net/posts?tags=rating:safe",
 },
 
 )

--- a/test/results/endchan.py
+++ b/test/results/endchan.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://endchan.org/yuri/res/33621.html",
     "#category": ("lynxchan", "endchan", "thread"),
     "#class"   : lynxchan.LynxchanThreadExtractor,
-    "#urls"    : "https://endchan.org/.media/358c089df4be990e9f7b636e1ce83d3e-imagejpeg.jpg",
+    "#results" : "https://endchan.org/.media/358c089df4be990e9f7b636e1ce83d3e-imagejpeg.jpg",
 },
 
 {

--- a/test/results/exhentai.py
+++ b/test/results/exhentai.py
@@ -125,7 +125,7 @@ __tests__ = (
     "#category": ("", "exhentai", "favorite"),
     "#class"   : exhentai.ExhentaiFavoriteExtractor,
     "#auth"    : True,
-    "#urls"    : "https://e-hentai.org/g/1200119/d55c44d3d0/",
+    "#results" : "https://e-hentai.org/g/1200119/d55c44d3d0/",
 },
 
 {

--- a/test/results/fanbox.py
+++ b/test/results/fanbox.py
@@ -146,12 +146,12 @@ __tests__ = (
     "#class"   : fanbox.FanboxPostExtractor,
     "#options" : {"metadata": "comments"},
     "#sha1_url": "c92ddd06f2efc4a5fe30ec67e21544f79a5c4062",
-    "#urls"    : [
+    "#results" : (
         "https://pixiv.pximg.net/fanbox/public/images/post/3746116/cover/6h5w7F1MJWLeED6ODfHo6ZYQ.jpeg",
         "https://downloads.fanbox.cc/images/post/3746116/ouTz7XZIeVD3FBOzoLhJ3ZTA.jpeg",
         "https://downloads.fanbox.cc/images/post/3746116/hBs9bXEg6HvbqWT8QLD9g5ne.jpeg",
         "https://downloads.fanbox.cc/images/post/3746116/C93E7db3C3sBqbDw6gQoZBMz.jpeg",
-    ],
+    ),
 
     "archives": (),
     "comments": "len:4",
@@ -161,7 +161,7 @@ __tests__ = (
     "#url"     : "https://mochirong.fanbox.cc/posts/9809662",
     "#comment" : "'archives' metadata (#7454)",
     "#class"   : fanbox.FanboxPostExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://downloads.fanbox.cc/images/post/9809662/TUeXGybLxGVmzzrP8o3fhn27.jpeg",
         "https://downloads.fanbox.cc/images/post/9809662/qt5fZBGxErXDAgBf2qgUZ1O8.jpeg",
         "https://downloads.fanbox.cc/images/post/9809662/NvA7M0tIMGjA3sQxBqvdmwBm.jpeg",

--- a/test/results/fandom.py
+++ b/test/results/fandom.py
@@ -19,7 +19,7 @@ __tests__ = (
     "#url"     : "https://mushishi.fandom.com/wiki/Yahagi",
     "#category": ("wikimedia", "fandom-mushishi", "article"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#urls"    : "https://static.wikia.nocookie.net/mushi-shi/images/f/f8/Yahagi.png/revision/latest?cb=20150128052255",
+    "#results" : "https://static.wikia.nocookie.net/mushi-shi/images/f/f8/Yahagi.png/revision/latest?cb=20150128052255",
 
     "bitdepth"      : 8,
     "canonicaltitle": "File:Yahagi.png",
@@ -97,7 +97,7 @@ __tests__ = (
     "#comment" : "non-English language prefix (#6370)",
     "#category": ("wikimedia", "fandom-discogs", "file"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#urls"    : "https://static.wikia.nocookie.net/discogs/images/a/ab/CH-0430D2.jpg/revision/latest?cb=20241007150151&path-prefix=zh",
+    "#results" : "https://static.wikia.nocookie.net/discogs/images/a/ab/CH-0430D2.jpg/revision/latest?cb=20241007150151&path-prefix=zh",
 },
 
 {

--- a/test/results/flickr.py
+++ b/test/results/flickr.py
@@ -18,7 +18,7 @@ __tests__ = (
         "exif": True,
         "profile": True,
     },
-    "#urls"        : "https://live.staticflickr.com/7463/16089302239_de18cd8017_b_d.jpg",
+    "#results"     : "https://live.staticflickr.com/7463/16089302239_de18cd8017_b_d.jpg",
     "#pattern"     : flickr.FlickrImageExtractor.pattern,
     "#sha1_content": [
         "3133006c6d657fe54cf7d4c46b82abbcb0efaf9f",
@@ -202,7 +202,7 @@ __tests__ = (
         "info": True,
         "profile": True,
     },
-    "#urls"    : (
+    "#results" : (
         "https://live.staticflickr.com/7322/8719105033_4a21140220_o_d.jpg",
         "https://live.staticflickr.com/7376/8720226282_eae0faefd1_o_d.jpg",
         "https://live.staticflickr.com/7460/8720245516_ab06f80353_o_d.jpg",

--- a/test/results/furry34.py
+++ b/test/results/furry34.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#comment": "image",
     "#class"  : furry34.Furry34PostExtractor,
     "#options"     : {"tags": True},
-    "#urls"        : "https://furry34com.b-cdn.net/posts/541/541949/541949.pic.jpg",
+    "#results"     : "https://furry34com.b-cdn.net/posts/541/541949/541949.pic.jpg",
     "#sha1_content": "4880da04f7fb41b1760aad4c8297c9917aeeec53",
 
     "created"   : "2024-09-20T19:49:47.443232Z",
@@ -121,7 +121,7 @@ __tests__ = (
     "#url"    : "https://furry34.com/post/605309",
     "#comment": "video",
     "#class"  : furry34.Furry34PostExtractor,
-    "#urls"        : "https://furry34.com/posts/605/605309/605309.mov.mp4",
+    "#results"     : "https://furry34.com/posts/605/605309/605309.mov.mp4",
     "#sha1_content": "914d00e2a6cfee73547bae266ec4b7aaee5aadf2",
 
     "type": 1,

--- a/test/results/gelbooru.py
+++ b/test/results/gelbooru.py
@@ -66,7 +66,7 @@ __tests__ = (
     "#url"     : "https://gelbooru.com/index.php?page=favorites&s=view&id=1435674",
     "#category": ("booru", "gelbooru", "favorite"),
     "#class"   : gelbooru.GelbooruFavoriteExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://img4.gelbooru.com/images/5d/30/5d30fc056ed8668616b3c440df9bac89.jpg",
         "https://img4.gelbooru.com/images/4c/2d/4c2da867ed643acdadd8105177dcdaf0.png",
         "https://img4.gelbooru.com/images/c8/26/c826f3cb90d9aaca8d0632a96bf4abe8.jpg",
@@ -80,7 +80,7 @@ __tests__ = (
     "#category": ("booru", "gelbooru", "favorite"),
     "#class"   : gelbooru.GelbooruFavoriteExtractor,
     "#options" : {"order-posts": "reverse"},
-    "#urls"    : (
+    "#results" : (
         "https://img4.gelbooru.com/images/e6/6d/e66d8883c184f5d3b2591dfcdf0d007c.jpg",
         "https://img4.gelbooru.com/images/c1/fe/c1fe59c0bc8ce955dd353544b1015d0c.jpg",
         "https://img4.gelbooru.com/images/c8/26/c826f3cb90d9aaca8d0632a96bf4abe8.jpg",

--- a/test/results/giantessbooru.py
+++ b/test/results/giantessbooru.py
@@ -33,7 +33,7 @@ __tests__ = (
     "#url"     : "https://sizechangebooru.com/index.php?q=/post/view/41",
     "#category": ("shimmie2", "giantessbooru", "post"),
     "#class"   : shimmie2.Shimmie2PostExtractor,
-    "#urls"        : "https://sizechangebooru.com/index.php?q=/image/41.jpg",
+    "#results"     : "https://sizechangebooru.com/index.php?q=/image/41.jpg",
     "#sha1_content": "79115ed309d1f4e82e7bead6948760e889139c91",
 
     "extension": "jpg",

--- a/test/results/hentaifoundry.py
+++ b/test/results/hentaifoundry.py
@@ -118,7 +118,7 @@ __tests__ = (
     "#comment" : "SWF / rumble embed (#4641)",
     "#category": ("", "hentaifoundry", "image"),
     "#class"   : hentaifoundry.HentaifoundryImageExtractor,
-    "#urls"    : "https://pictures.hentai-foundry.com/s/Soloid/186714/Soloid-186714-Osaloop.swf",
+    "#results" : "https://pictures.hentai-foundry.com/s/Soloid/186714/Soloid-186714-Osaloop.swf",
 
     "artist"     : "Soloid",
     "date"       : "dt:2013-02-07 17:25:54",

--- a/test/results/horne.py
+++ b/test/results/horne.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#url"     : "https://horne.red/members.php?id=58000",
     "#category": ("Nijie", "horne", "user"),
     "#class"   : nijie.NijieUserExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://horne.red/members_illust.php?id=58000",
         "https://horne.red/members_dojin.php?id=58000",
     ),
@@ -79,7 +79,7 @@ __tests__ = (
     "#url"     : "https://horne.red/view.php?id=8708",
     "#category": ("Nijie", "horne", "image"),
     "#class"   : nijie.NijieImageExtractor,
-    "#urls"    : "https://pic.nijie.net/__s4__/d7e18cb679f35b388dc8b0b9f2edb178078469b8970ee099cd573a577bc3a84cf33a04581f20b1cbed44bcd86147348cccdf7ded3b974bfb5b2711c2afb27c67834a22bd7411aa43895c9f480bbbed7373d345c24ac55e36018ad065.png",
+    "#results" : "https://pic.nijie.net/__s4__/d7e18cb679f35b388dc8b0b9f2edb178078469b8970ee099cd573a577bc3a84cf33a04581f20b1cbed44bcd86147348cccdf7ded3b974bfb5b2711c2afb27c67834a22bd7411aa43895c9f480bbbed7373d345c24ac55e36018ad065.png",
 
     "artist_id"  : 58000,
     "artist_name": "のえるわ",
@@ -105,7 +105,7 @@ __tests__ = (
     "#url"     : "https://horne.red/view.php?id=8716",
     "#category": ("Nijie", "horne", "image"),
     "#class"   : nijie.NijieImageExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://pic.nijie.net/__s4__/d7b784b573f850628fcae5b4f7ede679085af22dba0caf6bb91622438289ddce9312ab6f2886b8d8ef104f8eb5908d57cc309ec0239464add9f9d8d17d83c39d92c680b083f107d63c68eef29938ebc937699fd50d51b1128404cc6e.png",
         "https://pic.nijie.net/__s4__/d7b9dae222f25e388a9debb4ade7eb79b87af28c9650b1babe514902eb854bbd8cb295b379d5480ea83cad78fbc843b146785ba59f1279fa77eb14e33ca66778474afb5063ba36d9d527fa31f780fbf396b27bd9901b0e3565efce08.png",
         "https://pic.nijie.net/__s4__/d7b889b276fb5a36dacde5bef7e8ea225e06c9904f18be00035c96721dd1ac6ab7217be29f8c6f58626aa9839835185f08474efd3822a3e298c74b9f2b3d0fc1cd5400b97b74512b0800eabbdcf8d4094be666ea3b6305a436cadd10.png",

--- a/test/results/hotleak.py
+++ b/test/results/hotleak.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#url"     : "https://hotleak.vip/kaiyakawaii/photo/1617145",
     "#category": ("", "hotleak", "post"),
     "#class"   : hotleak.HotleakPostExtractor,
-    "#urls"    : "https://image-cdn.hotleak.vip/storage/images/e98/18ad68/18ad68.webp",
+    "#results" : "https://image-cdn.hotleak.vip/storage/images/e98/18ad68/18ad68.webp",
 
     "id"       : 1617145,
     "creator"  : "kaiyakawaii",

--- a/test/results/imagefap.py
+++ b/test/results/imagefap.py
@@ -134,7 +134,7 @@ __tests__ = (
     "#url"     : "https://www.imagefap.com/usergallery.php?userid=1981976&folderid=409758",
     "#category": ("", "imagefap", "folder"),
     "#class"   : imagefap.ImagefapFolderExtractor,
-    "#urls"    : "https://www.imagefap.com/gallery/7876223",
+    "#results" : "https://www.imagefap.com/gallery/7876223",
 
     "folder"    : "Softcore",
     "gallery_id": "7876223",

--- a/test/results/imagepond.py
+++ b/test/results/imagepond.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://imagepond.net/image/IMG-20250217-160622.TJNphg",
     "#category": ("chevereto", "imagepond", "image"),
     "#class"   : chevereto.CheveretoImageExtractor,
-    "#urls"        : "https://media.imagepond.net/media/IMG_20250217_1606226b345a5dbd0e8971.jpg",
+    "#results"     : "https://media.imagepond.net/media/IMG_20250217_1606226b345a5dbd0e8971.jpg",
     "#sha1_content": "ec7fac6b427f7af01038619208cd69478e91ddef",
 
     "album"    : "",

--- a/test/results/imagetwist.py
+++ b/test/results/imagetwist.py
@@ -45,7 +45,7 @@ __tests__ = (
     "#url"     : "https://imagetwist.com/p/gdldev/747223/digits",
     "#category": ("imagehost", "imagetwist", "gallery"),
     "#class"   : imagehosts.ImagetwistGalleryExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://imagetwist.com/j6eu91sbl9bs",
         "https://imagetwist.com/vx4oh119izyr",
         "https://imagetwist.com/n3td3a6vzzed",

--- a/test/results/imagevenue.py
+++ b/test/results/imagevenue.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://www.imagevenue.com/ME13LS07",
     "#category": ("imagehost", "imagevenue", "image"),
     "#class"   : imagehosts.ImagevenueImageExtractor,
-    "#urls"         : "https://cdn-images.imagevenue.com/10/ac/05/ME13LS07_o.png",
+    "#results"      : "https://cdn-images.imagevenue.com/10/ac/05/ME13LS07_o.png",
     "#sha1_metadata": "ae15d6e3b2095f019eee84cd896700cd34b09c36",
     "#sha1_content" : "cfaa8def53ed1a575e0c665c9d6d8cf2aac7a0ee",
 
@@ -25,7 +25,7 @@ __tests__ = (
     "#url"     : "https://www.imagevenue.com/view/o?i=92518_13732377annakarina424200712535AM_122_486lo.jpg&h=img150&l=loc486",
     "#category": ("imagehost", "imagevenue", "image"),
     "#class"   : imagehosts.ImagevenueImageExtractor,
-    "#urls"    : "https://cdno-data.imagevenue.com/html.img150/upload2328/loc486/92518_13732377annakarina424200712535AM_122_486lo.jpg",
+    "#results" : "https://cdno-data.imagevenue.com/html.img150/upload2328/loc486/92518_13732377annakarina424200712535AM_122_486lo.jpg",
     "#sha1_url": "8bf0254e29250d8f5026c0105bbdda3ee3d84980",
 },
 
@@ -33,7 +33,7 @@ __tests__ = (
     "#url"     : "http://img28116.imagevenue.com/img.php?image=th_52709_test_122_64lo.jpg",
     "#category": ("imagehost", "imagevenue", "image"),
     "#class"   : imagehosts.ImagevenueImageExtractor,
-    "#urls"    : "https://cdno-data.imagevenue.com/html.img8116/upload2328/loc64/th_52709_test_122_64lo.jpg",
+    "#results" : "https://cdno-data.imagevenue.com/html.img8116/upload2328/loc64/th_52709_test_122_64lo.jpg",
     "#sha1_url": "f98e3091df7f48a05fb60fbd86f789fc5ec56331",
 },
 
@@ -42,7 +42,7 @@ __tests__ = (
     "#comment" : "404 image (#7570)",
     "#category": ("imagehost", "imagevenue", "image"),
     "#class"   : imagehosts.ImagevenueImageExtractor,
-    "#urls"        : "https://cdno-data.imagevenue.com/html.img159/upload2328/loc83/73874_203_123_83lo.jpg",
+    "#results"     : "https://cdno-data.imagevenue.com/html.img159/upload2328/loc83/73874_203_123_83lo.jpg",
     "#sha1_content": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
 },
 

--- a/test/results/imgkiwi.py
+++ b/test/results/imgkiwi.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://img.kiwi/image/79de2c41-70f9-4a87-bd6d-00fe9997c0c4.JR2wZz",
     "#category": ("chevereto", "imgkiwi", "image"),
     "#class"   : chevereto.CheveretoImageExtractor,
-    "#urls"        : "https://img.kiwi/images/2023/02/28/11ac1ebf28a2eae8265026b28e9c4413.jpg",
+    "#results"     : "https://img.kiwi/images/2023/02/28/11ac1ebf28a2eae8265026b28e9c4413.jpg",
     "#sha1_content": "9ea704a77e2038b9008350682cfad53a614a60bd",
 
     "album"    : "Kins3y Wolansk1",

--- a/test/results/imgspice.py
+++ b/test/results/imgspice.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://imgspice.com/q1taxkhxprrn/58410038_cal022jsp_308191001.jpg.html",
     "#category": ("imagehost", "imgspice", "image"),
     "#class"   : imagehosts.ImgspiceImageExtractor,
-    "#urls"         : "https://img30.imgspice.com/i/03792/q1taxkhxprrn.jpg",
+    "#results"      : "https://img30.imgspice.com/i/03792/q1taxkhxprrn.jpg",
     "#sha1_content" : "f1de8e58a7c2ef747a206a38f96c5623b8a83edc",
 
     "extension": "jpg",

--- a/test/results/imgur.py
+++ b/test/results/imgur.py
@@ -16,7 +16,7 @@ __tests__ = (
     "#class"   : imgur.ImgurImageExtractor,
     "#sha1_url"    : "6f2dcfb86815bdd72808c313e5f715610bc7b9b2",
     "#sha1_content": "0c8768055e4e20e7c7259608b67799171b691140",
-    "#urls"        : "https://i.imgur.com/21yMxCS.png",
+    "#results"     : "https://i.imgur.com/21yMxCS.png",
 
     "account_id"    : 0,
     "comment_count" : int,
@@ -167,7 +167,7 @@ __tests__ = (
     "#category": ("", "imgur", "album"),
     "#class"   : imgur.ImgurAlbumExtractor,
     "#sha1_url": "ce3552f550a5b5316bd9c7ae02e21e39f30c0563",
-    "#urls"    : (
+    "#results" : (
         "https://i.imgur.com/693j2Kr.jpg",
         "https://i.imgur.com/ZNalkAC.jpg",
         "https://i.imgur.com/lMox9Ek.jpg",

--- a/test/results/instagram.py
+++ b/test/results/instagram.py
@@ -14,7 +14,7 @@ __tests__ = (
     "#class"   : instagram.InstagramUserExtractor,
     "#auth"    : False,
     "#options" : {"include": "all"},
-    "#urls": [
+    "#results" : (
         "https://www.instagram.com/instagram/info/",
         "https://www.instagram.com/instagram/avatar/",
         "https://www.instagram.com/stories/instagram/",
@@ -22,7 +22,7 @@ __tests__ = (
         "https://www.instagram.com/instagram/posts/",
         "https://www.instagram.com/instagram/reels/",
         "https://www.instagram.com/instagram/tagged/",
-    ],
+    ),
 },
 
 {

--- a/test/results/itaku.py
+++ b/test/results/itaku.py
@@ -22,7 +22,7 @@ __tests__ = (
     "#comment" : "gallery section (#6951)",
     "#category": ("", "itaku", "gallery"),
     "#class"   : itaku.ItakuGalleryExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://itaku.ee/api/media/gallery_imgs/misty-psyduck_IWbYdwT.png",
         "https://itaku.ee/api/media/gallery_imgs/bea_alpha_N0YGfeT.png",
     ),
@@ -43,7 +43,7 @@ __tests__ = (
     "#url"     : "https://itaku.ee/images/100471",
     "#category": ("", "itaku", "image"),
     "#class"   : itaku.ItakuImageExtractor,
-    "#urls"    : "https://itaku.ee/api/media/gallery_imgs/220504_oUNIAFT.png",
+    "#results" : "https://itaku.ee/api/media/gallery_imgs/220504_oUNIAFT.png",
 
     "already_pinned"  : None,
     "blacklisted"     : {
@@ -97,7 +97,7 @@ __tests__ = (
     "#comment" : "video",
     "#category": ("", "itaku", "image"),
     "#class"   : itaku.ItakuImageExtractor,
-    "#urls"    : "https://itaku.ee/api/media/gallery_vids/sleepy_af_OY5GHWw.mp4",
+    "#results" : "https://itaku.ee/api/media/gallery_vids/sleepy_af_OY5GHWw.mp4",
 },
 
 {

--- a/test/results/jpgfish.py
+++ b/test/results/jpgfish.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://jpg4.su/img/funnymeme.LecXGS",
     "#category": ("chevereto", "jpgfish", "image"),
     "#class"   : chevereto.CheveretoImageExtractor,
-    "#urls"        : "https://simp3.jpg5.su/images/funnymeme.jpg",
+    "#results"     : "https://simp3.jpg5.su/images/funnymeme.jpg",
     "#sha1_content": "098e5e9b17ad634358426e0ffd1c93871474d13c",
 
     "album"    : "",

--- a/test/results/kemono.py
+++ b/test/results/kemono.py
@@ -113,7 +113,7 @@ __tests__ = (
     "#comment" : "search / 'q' query parameter (#3385, #4057)",
     "#category": ("", "kemono", "fanbox"),
     "#class"   : kemono.KemonoUserExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/data/ef/7b/ef7b4398a2f4ada597421fd3c116cff86e85695911f7cd2a459b0e566b864e46.png",
         "https://kemono.su/data/73/e6/73e615f6645b9d1af6329448601673c9275f07fd11eb37670c97e307e29a9ee9.png",
     ),
@@ -126,7 +126,7 @@ __tests__ = (
     "#comment" : "'tag' query parameter",
     "#category": ("", "kemono", "patreon"),
     "#class"   : kemono.KemonoUserExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/data/83/61/8361560887a09c7b828d326b3e1a2f0288673741569a09d74bcd01e602d20db1.png",
         "https://kemono.su/data/03/e6/03e62592c3b616b8906c1aaa130bd9ceaa24d7f601b31f90cc11956a57ca1d82.png",
         "https://kemono.su/data/83/0d/830d017873157d2e6544a0f23a47622ec1e91be09b5d7795eb22e32b3150c837.png",
@@ -313,7 +313,7 @@ __tests__ = (
     "#comment" : "revisions (#4498)",
     "#category": ("", "kemono", "patreon"),
     "#class"   : kemono.KemonoPostExtractor,
-    "#urls"    : "https://kemono.su/data/88/52/88521f71822dfa2f42df3beba319ea4fceda2a2d6dc59da0276a75238f743f86.jpg",
+    "#results" : "https://kemono.su/data/88/52/88521f71822dfa2f42df3beba319ea4fceda2a2d6dc59da0276a75238f743f86.jpg",
 
     "file": {
         "hash": "88521f71822dfa2f42df3beba319ea4fceda2a2d6dc59da0276a75238f743f86",
@@ -344,7 +344,7 @@ __tests__ = (
     "#category": ("", "kemono", "patreon"),
     "#class"   : kemono.KemonoPostExtractor,
     "#options" : {"revisions": "unique"},
-    "#urls"    : "https://kemono.su/data/e3/e6/e3e6287dbc0468dd2a9d28ed276ae86788907143acf2ba10ab886a3add4c436c.jpg",
+    "#results" : "https://kemono.su/data/e3/e6/e3e6287dbc0468dd2a9d28ed276ae86788907143acf2ba10ab886a3add4c436c.jpg",
     "#archive" : False,
 
     "filename"      : "wip update",
@@ -496,7 +496,7 @@ __tests__ = (
     "#comment" : r"'\' in file paths",
     "#category": ("", "kemono", "boosty"),
     "#class"   : kemono.KemonoPostExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/data/dd/35/dd35c43d8a93f1806f094d9331a17c5037ed5d93e0f30c28d3cca2056b400aa6.png",
         "https://kemono.su/data/25/48/254864eb2523ab48be8d3fb7ad21ab3a127d61736b76602f8421cde88700a174.png",
     ),
@@ -620,7 +620,7 @@ __tests__ = (
     "#class"   : kemono.KemonoFavoriteExtractor,
     "#pattern" : kemono.KemonoUserExtractor.pattern,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/patreon/user/881792",
         "https://kemono.su/fanbox/user/6993449",
         "https://kemono.su/subscribestar/user/alcorart",
@@ -634,7 +634,7 @@ __tests__ = (
     "#class"   : kemono.KemonoFavoriteExtractor,
     "#pattern" : kemono.KemonoUserExtractor.pattern,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/fanbox/user/6993449",
         "https://kemono.su/patreon/user/881792",
         "https://kemono.su/subscribestar/user/alcorart",
@@ -648,7 +648,7 @@ __tests__ = (
     "#class"   : kemono.KemonoFavoriteExtractor,
     "#pattern" : kemono.KemonoPostExtractor.pattern,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/subscribestar/user/alcorart/post/184329",
         "https://kemono.su/fanbox/user/6993449/post/23913",
         "https://kemono.su/patreon/user/881792/post/4769638",
@@ -661,7 +661,7 @@ __tests__ = (
     "#class"   : kemono.KemonoFavoriteExtractor,
     "#pattern" : kemono.KemonoPostExtractor.pattern,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/patreon/user/881792/post/4769638",
         "https://kemono.su/fanbox/user/6993449/post/23913",
         "https://kemono.su/subscribestar/user/alcorart/post/184329",
@@ -685,7 +685,7 @@ __tests__ = (
     "#category": ("", "kemono", "artists"),
     "#class"   : kemono.KemonoArtistsExtractor,
     "#pattern" : kemono.KemonoUserExtractor.pattern,
-    "#urls"    : (
+    "#results" : (
         "https://kemono.su/patreon/user/91205314",
         "https://kemono.su/patreon/user/51528107",
         "https://kemono.su/fanbox/user/12812028",
@@ -716,7 +716,7 @@ __tests__ = (
     "#category": ("", "kemono", "artists"),
     "#class"   : kemono.KemonoArtistsExtractor,
     "#pattern" : kemono.KemonoDiscordServerExtractor.pattern,
-    "#urls"    : "https://kemono.su/discord/server/1168450323023663164",
+    "#results" : "https://kemono.su/discord/server/1168450323023663164",
 
     "favorited": range(40, 80),
     "id"       : "1168450323023663164",

--- a/test/results/khinsider.py
+++ b/test/results/khinsider.py
@@ -62,7 +62,7 @@ __tests__ = (
     "#class": khinsider.KhinsiderSoundtrackExtractor,
     "#options": {"covers": True},
     "#range"  : "1-10",
-    "#urls"   : (
+    "#results": (
         "https://vgmsite.com/soundtracks/super-mario-64-soundtrack/00%20Front.jpg",
         "https://vgmsite.com/soundtracks/super-mario-64-soundtrack/01%20Back.jpg",
         "https://vgmsite.com/soundtracks/super-mario-64-soundtrack/02%20Booklet%20Front%20and%20Back.jpg",

--- a/test/results/lensdump.py
+++ b/test/results/lensdump.py
@@ -32,7 +32,7 @@ __tests__ = (
 {
     "#url"     : "https://lensdump.com/vstar925",
     "#class"   : lensdump.LensdumpAlbumsExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://lensdump.com/a/tX1uA",
         "https://lensdump.com/a/R0gfK",
         "https://lensdump.com/a/RSOMv",
@@ -44,7 +44,7 @@ __tests__ = (
     "#url"     : "https://lensdump.com/vstar925/?sort=likes_desc&page=1",
     "#comment" : "custom sort order",
     "#class"   : lensdump.LensdumpAlbumsExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://lensdump.com/a/9TbdT",
         "https://lensdump.com/a/RSOMv",
         "https://lensdump.com/a/R0gfK",
@@ -60,7 +60,7 @@ __tests__ = (
 {
     "#url"     : "https://lensdump.com/i/tyoAyM",
     "#class"   : lensdump.LensdumpImageExtractor,
-    "#urls"        : "https://c.l3n.co/i/tyoAyM.webp",
+    "#results"     : "https://c.l3n.co/i/tyoAyM.webp",
     "#sha1_content": "1aa749ed2c0cf679ec8e1df60068edaf3875de46",
 
     "date"     : "dt:2022-08-01 08:24:28",
@@ -76,7 +76,7 @@ __tests__ = (
 {
     "#url"     : "https://c.l3n.co/i/tyoAyM.webp",
     "#class"   : lensdump.LensdumpImageExtractor,
-    "#urls"    : "https://c.l3n.co/i/tyoAyM.webp",
+    "#results" : "https://c.l3n.co/i/tyoAyM.webp",
 
     "date"     : "dt:2022-08-01 08:24:28",
     "extension": "webp",

--- a/test/results/lofter.py
+++ b/test/results/lofter.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"  : "https://gengar563.lofter.com/post/1e82da8c_1c98dae1b",
     "#class": lofter.LofterPostExtractor,
-    "#urls" : (
+    "#results": (
         "https://imglf3.lf127.net/img/S1d2QlVsWkJhSW1qcnpIS0ZSa3ZJQ1RxY0lYaU1UUE9tQ0NvUE9rVXFpOFFEVzMwbnQ4aEFnPT0.jpg",
         "https://imglf3.lf127.net/img/S1d2QlVsWkJhSW1qcnpIS0ZSa3ZJRWlXYTRVOEpXTU9TSGt3TjBDQ0JFZVpZMEJtWjFneVNBPT0.png",
         "https://imglf6.lf127.net/img/S1d2QlVsWkJhSW1qcnpIS0ZSa3ZJR1d3Y2VvbTNTQlIvdFU1WWlqZHEzbjI4MFVNZVdoN3VBPT0.png",
@@ -31,7 +31,7 @@ __tests__ = (
     "#url"    : "https://wooden-brain.lofter.com/post/1e60de5b_1c9bf8efb",
     "#comment": "video",
     "#class"  : lofter.LofterPostExtractor,
-    "#urls"   : (
+    "#results": (
         "https://vodm2lzexwq.vod.126.net/vodm2lzexwq/Pc5jg1nL_3039990631_sd.mp4?resId=254486990bfa2cd7aa860229db639341_3039990631_1&sign=4j02HTHXqNfhaF%2B%2FO14Ny%2F9SMNZj%2FIjpJDCqXfYa4aM%3D",
     ),
 

--- a/test/results/mangadex.py
+++ b/test/results/mangadex.py
@@ -123,7 +123,7 @@ __tests__ = (
     "#url"     : "https://mangadex.org/titles/follows",
     "#class"   : mangadex.MangadexFollowingExtractor,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://mangadex.org/title/cad76ec6-ca22-42f6-96f8-eca164da6545",
         "https://mangadex.org/title/7546ff2d-2310-47a4-b1f3-1a2561f20ce7",
     ),
@@ -139,7 +139,7 @@ __tests__ = (
     "#url"     : "https://mangadex.org/list/3a0982c5-65aa-4de2-8a4a-2175be7383ab/test",
     "#category": ("", "mangadex", "list"),
     "#class"   : mangadex.MangadexListExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://mangadex.org/title/cba4e5d6-67a0-47a0-b37a-c06e9bf25d93",
         "https://mangadex.org/title/cad76ec6-ca22-42f6-96f8-eca164da6545",
     ),
@@ -155,7 +155,7 @@ __tests__ = (
     "#url"     : "https://mangadex.org/list/3a0982c5-65aa-4de2-8a4a-2175be7383ab/test?tab=feed",
     "#category": ("", "mangadex", "list-feed"),
     "#class"   : mangadex.MangadexListExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://mangadex.org/chapter/c765d6d5-5712-4360-be0b-0c8e0914fc94",
         "https://mangadex.org/chapter/fa8a695d-260f-4dcc-95a3-1f30e66d6571",
         "https://mangadex.org/chapter/788766b9-41c6-422e-97ba-552f03ba9655",
@@ -165,7 +165,7 @@ __tests__ = (
 {
     "#url"     : "https://mangadex.org/author/7222d0d5-836c-4bf3-9174-72bceade8c87/kotoyama",
     "#class"   : mangadex.MangadexAuthorExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://mangadex.org/title/ef4ead73-57a7-4d10-95b3-de73cfdd2670",
         "https://mangadex.org/title/259dfd8a-f06a-4825-8fa6-a2dcd7274230",
         "https://mangadex.org/title/d0c88e3b-ea64-4e07-9841-c1d2ac982f4a",

--- a/test/results/mastodon.py
+++ b/test/results/mastodon.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#comment" : "Akkoma - /:user/:status_id",
     "#category": ("mastodon", "donotsta.re", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://asdf.donotsta.re/media/917e7722dd30d510686ce9f3717a1f722dac96fd974b5af5ec2ccbc8cbd740c6.png",
+    "#results" : "https://asdf.donotsta.re/media/917e7722dd30d510686ce9f3717a1f722dac96fd974b5af5ec2ccbc8cbd740c6.png",
 
     "instance": "donotsta.re",
     "instance_remote": None,
@@ -24,7 +24,7 @@ __tests__ = (
     "#comment" : "null moved account",
     "#category": ("mastodon", "wanderingwires.net", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://s3.wanderingwires.net/null/4377e826-72ab-4659-885c-fa12945eb207.png",
+    "#results" : "https://s3.wanderingwires.net/null/4377e826-72ab-4659-885c-fa12945eb207.png",
 
     "instance": "wanderingwires.net",
     "instance_remote": None,
@@ -35,7 +35,7 @@ __tests__ = (
     "#comment" : "Akkoma - /notice/:status_id",
     "#category": ("mastodon", "woem.space", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://nbg1.your-objectstorage.com/woem-space/261f4f482e1cb641db732dab91f0177b1f5ea0bcf008f4831c593ff718dff4fe.jpg",
+    "#results" : "https://nbg1.your-objectstorage.com/woem-space/261f4f482e1cb641db732dab91f0177b1f5ea0bcf008f4831c593ff718dff4fe.jpg",
 
     "instance" : "woem.space",
     "instance_remote": None,
@@ -46,7 +46,7 @@ __tests__ = (
     "#comment" : "Akkoma - /notice/:status_id",
     "#category": ("mastodon", "labyrinth.zone", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://media.labyrinth.zone/media/96e10a9e3b0f24f63713d8a03e939eec7f9e636cdef57a14c389163f58e60947.png",
+    "#results" : "https://media.labyrinth.zone/media/96e10a9e3b0f24f63713d8a03e939eec7f9e636cdef57a14c389163f58e60947.png",
 
     "instance" : "labyrinth.zone",
     "instance_remote": None,
@@ -57,7 +57,7 @@ __tests__ = (
     "#comment" : "Pleroma - /notice/:status_id",
     "#category": ("mastodon", "udongein.xyz", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://statics.udongein.xyz/udongein/cc3c7a8b749cd88298fda6553e10f81f9c4de280f03ad107ed25a439e6be23eb.jpg?name=Husky_1743801357069_6QIL5OZLXK.jpg",
+    "#results" : "https://statics.udongein.xyz/udongein/cc3c7a8b749cd88298fda6553e10f81f9c4de280f03ad107ed25a439e6be23eb.jpg?name=Husky_1743801357069_6QIL5OZLXK.jpg",
 
     "instance" : "udongein.xyz",
     "instance_remote": None,
@@ -68,7 +68,7 @@ __tests__ = (
     "#comment" : "Mastodon - /:user/:status_id",
     "#category": ("mastodon", "freeradical.zone", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://nfts.freeradical.zone/media_attachments/files/114/477/182/897/690/030/original/96700c8ae9a79651.png",
+    "#results" : "https://nfts.freeradical.zone/media_attachments/files/114/477/182/897/690/030/original/96700c8ae9a79651.png",
 
     "instance" : "freeradical.zone",
     "instance_remote": None,
@@ -79,7 +79,7 @@ __tests__ = (
     "#comment" : "/objects/:uuid (#7497)",
     "#category": ("mastodon", "labyrinth.zone", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
-    "#urls"    : "https://media.labyrinth.zone/media/96e10a9e3b0f24f63713d8a03e939eec7f9e636cdef57a14c389163f58e60947.png",
+    "#results" : "https://media.labyrinth.zone/media/96e10a9e3b0f24f63713d8a03e939eec7f9e636cdef57a14c389163f58e60947.png",
 
     "instance" : "labyrinth.zone",
     "instance_remote": None,

--- a/test/results/mastodonsocial.py
+++ b/test/results/mastodonsocial.py
@@ -33,7 +33,7 @@ __tests__ = (
     "#class"   : mastodon.MastodonUserExtractor,
     "#options" : {"reblogs": True},
     "#archive" : False,
-    "#urls": (
+    "#results": (
         "https://files.mastodon.social/media_attachments/files/111/330/852/486/713/967/original/2c25ade55a9d1af2.jpg",
         "https://files.mastodon.social/media_attachments/files/111/331/603/082/304/823/original/e12cde371c88c1b0.png",
         "https://files.mastodon.social/media_attachments/files/111/331/603/082/304/823/original/e12cde371c88c1b0.png",
@@ -75,7 +75,7 @@ __tests__ = (
     "#category": ("mastodon", "mastodon.social", "bookmark"),
     "#class"   : mastodon.MastodonBookmarkExtractor,
     "#auth"    : True,
-    "#urls"    : "https://files.mastodon.social/media_attachments/files/111/331/603/082/304/823/original/e12cde371c88c1b0.png",
+    "#results" : "https://files.mastodon.social/media_attachments/files/111/331/603/082/304/823/original/e12cde371c88c1b0.png",
 },
 
 {
@@ -83,7 +83,7 @@ __tests__ = (
     "#category": ("mastodon", "mastodon.social", "favorite"),
     "#class"   : mastodon.MastodonFavoriteExtractor,
     "#auth"    : True,
-    "#urls"    : "https://files.mastodon.social/media_attachments/files/111/331/603/082/304/823/original/e12cde371c88c1b0.png",
+    "#results" : "https://files.mastodon.social/media_attachments/files/111/331/603/082/304/823/original/e12cde371c88c1b0.png",
 },
 
 {
@@ -108,7 +108,7 @@ __tests__ = (
     "#category": ("mastodon", "mastodon.social", "following"),
     "#class"   : mastodon.MastodonFollowingExtractor,
     "#extractor": False,
-    "#urls"     : (
+    "#results"  : (
         "https://mastodon.ie/@RustyBertrand",
         "https://ravenation.club/@soundwarrior20",
         "https://mastodon.social/@0x4f",
@@ -185,7 +185,7 @@ __tests__ = (
     "#category": ("mastodon", "mastodon.social", "status"),
     "#class"   : mastodon.MastodonStatusExtractor,
     "#options" : {"cards": True},
-    "#urls"    : "https://files.mastodon.social/cache/preview_cards/images/095/900/335/original/83f0b4a793c84123.jpg",
+    "#results" : "https://files.mastodon.social/cache/preview_cards/images/095/900/335/original/83f0b4a793c84123.jpg",
 
     "media": {
         "author_name" : "Tom Warren",

--- a/test/results/mediawiki.py
+++ b/test/results/mediawiki.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://www.mediawiki.org/wiki/Help:Navigation",
     "#category": ("wikimedia", "mediawiki", "help"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://upload.wikimedia.org/wikipedia/commons/e/ec/OOjs_UI_icon_information-progressive.svg",
         "https://upload.wikimedia.org/wikipedia/commons/6/62/PD-icon.svg",
         "https://upload.wikimedia.org/wikipedia/commons/0/0e/Vector_Sidebar.png",

--- a/test/results/misskeydesign.py
+++ b/test/results/misskeydesign.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#category": ("misskey", "misskey.design", "user"),
     "#class"   : misskey.MisskeyUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : (
+    "#results" : (
         "https://misskey.design/@machina_3D/info",
         "https://misskey.design/@machina_3D/avatar",
         "https://misskey.design/@machina_3D/banner",
@@ -34,7 +34,7 @@ __tests__ = (
     "#url"     : "https://misskey.design/@machina_3D/avatar",
     "#category": ("misskey", "misskey.design", "avatar"),
     "#class"   : misskey.MisskeyAvatarExtractor,
-    "#urls"    : "https://file.misskey.design/post/f2cd76a4-e5e5-4c46-b45d-5cd28e0fdafe.png",
+    "#results" : "https://file.misskey.design/post/f2cd76a4-e5e5-4c46-b45d-5cd28e0fdafe.png",
     "#sha1_content": "5ffa5b43513ed2e77f26ef9d49a91bb0d3e76847",
 
     "extension": "png",
@@ -49,7 +49,7 @@ __tests__ = (
     "#url"     : "https://misskey.design/@machina_3D/banner",
     "#category": ("misskey", "misskey.design", "background"),
     "#class"   : misskey.MisskeyBackgroundExtractor,
-    "#urls"    : "https://file.misskey.design/post/1ebf70d4-0175-454d-8d74-31829305582f.png",
+    "#results" : "https://file.misskey.design/post/1ebf70d4-0175-454d-8d74-31829305582f.png",
     "#sha1_content": "ba2d151e32114a894d342ed7408d970b9213e361",
 
     "extension": "png",
@@ -78,7 +78,7 @@ __tests__ = (
     "#url"     : "https://misskey.design/notes/9jva1danjc",
     "#category": ("misskey", "misskey.design", "note"),
     "#class"   : misskey.MisskeyNoteExtractor,
-    "#urls"    : "https://file.misskey.design/post/a8d27901-24e1-42ab-b8a6-1e09c98c6f55.webp",
+    "#results" : "https://file.misskey.design/post/a8d27901-24e1-42ab-b8a6-1e09c98c6f55.webp",
 },
 
 {

--- a/test/results/misskeyio.py
+++ b/test/results/misskeyio.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#category": ("misskey", "misskey.io", "user"),
     "#class"   : misskey.MisskeyUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : (
+    "#results" : (
         "https://misskey.io/@lithla/info",
         "https://misskey.io/@lithla/avatar",
         "https://misskey.io/@lithla/banner",
@@ -40,7 +40,7 @@ __tests__ = (
     "#url"     : "https://misskey.io/@lithla/avatar",
     "#category": ("misskey", "misskey.io", "avatar"),
     "#class"   : misskey.MisskeyAvatarExtractor,
-    "#urls"    : "https://media.misskeyusercontent.jp/io/d84e09f8-99b7-423a-9229-78ba65ab8a82.gif",
+    "#results" : "https://media.misskeyusercontent.jp/io/d84e09f8-99b7-423a-9229-78ba65ab8a82.gif",
     "#sha1_content": "375af4d302a4aef0bc8fc3f15b2c75ec952ac086",
 
     "extension": "gif",
@@ -55,7 +55,7 @@ __tests__ = (
     "#url"     : "https://misskey.io/@lithla/banner",
     "#category": ("misskey", "misskey.io", "background"),
     "#class"   : misskey.MisskeyBackgroundExtractor,
-    "#urls"    : "https://media.misskeyusercontent.jp/io/ddea6f5f-9cde-42ff-8e0b-dafbfa9cca9b.png",
+    "#results" : "https://media.misskeyusercontent.jp/io/ddea6f5f-9cde-42ff-8e0b-dafbfa9cca9b.png",
     "#sha1_content": "02e1d33a7aa03d8e63baa82ea6d75c7d5de80112",
 
     "extension": "png",
@@ -86,7 +86,7 @@ __tests__ = (
     "#url"     : "https://misskey.io/notes/9bhqfo835v",
     "#category": ("misskey", "misskey.io", "note"),
     "#class"   : misskey.MisskeyNoteExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://media.misskeyusercontent.jp/misskey/1cbba095-5a19-4107-8e20-3efb0456dda4.png?sensitive=true",
         "https://media.misskeyusercontent.jp/misskey/6baa558b-94ac-4bd2-a393-a52324a9d2d4.png?sensitive=true",
         "https://media.misskeyusercontent.jp/misskey/14133ad0-ea40-4fed-b6e7-65d4cbe19b96.png?sensitive=true",

--- a/test/results/motherless.py
+++ b/test/results/motherless.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"  : "https://motherless.com/B0168DB",
     "#class": motherless.MotherlessMediaExtractor,
-    "#urls" : "https://cdn5-images.motherlessmedia.com/images/B0168DB.jpg",
+    "#results": "https://cdn5-images.motherlessmedia.com/images/B0168DB.jpg",
     "#sha1_content": "10629fc5dd7a9623af7dd57f1a322d0f24ac9acc",
 
     "date"     : "dt:2013-03-29 00:00:00",
@@ -36,7 +36,7 @@ __tests__ = (
 {
     "#url"  : "https://motherless.com/G43D8704/F0C07D3",
     "#class": motherless.MotherlessMediaExtractor,
-    "#urls" : "https://cdn5-images.motherlessmedia.com/images/F0C07D3.jpg",
+    "#results": "https://cdn5-images.motherlessmedia.com/images/F0C07D3.jpg",
 
     "date"      : "dt:2014-08-13 00:00:00",
     "extension" : "jpg",
@@ -57,7 +57,7 @@ __tests__ = (
 {
     "#url"  : "https://motherless.com/g/classic_porn/19D6C80",
     "#class": motherless.MotherlessMediaExtractor,
-    "#urls" : "https://cdn5-images.motherlessmedia.com/images/19D6C80.gif",
+    "#results": "https://cdn5-images.motherlessmedia.com/images/19D6C80.gif",
 
     "date"     : "dt:2021-05-11 00:00:00",
     "extension": "gif",
@@ -76,7 +76,7 @@ __tests__ = (
 {
     "#url"  : "https://motherless.com/G43D8704",
     "#class": motherless.MotherlessGalleryExtractor,
-    "#urls": (
+    "#results": (
         "https://motherless.com/GI43D8704",
         "https://motherless.com/GV43D8704",
     ),

--- a/test/results/naver.py
+++ b/test/results/naver.py
@@ -29,7 +29,7 @@ __tests__ = (
     "#comment" : "filenames in EUC-KR encoding (#5126)",
     "#category": ("", "naver", "post"),
     "#class"   : naver.NaverPostExtractor,
-    "#urls": (
+    "#results": (
         "https://blogfiles.pstatic.net/20130305_23/ping9303_1362411028002Dpz9z_PNG/1_사본.png",
         "https://blogfiles.pstatic.net/20130305_46/rlfqjxm0_1362473322580x33zi_PNG/오마갓합작.png",
     ),
@@ -88,7 +88,7 @@ __tests__ = (
     "#category": ("", "naver", "post"),
     "#class"   : naver.NaverPostExtractor,
     "#options" : {"videos": False},
-    "#urls": (
+    "#results": (
         "https://blogfiles.pstatic.net/MjAyMzA5MjVfMTMy/MDAxNjk1NjQ0MzI4OTE3.UxgvxTesk7Y88OWGvPMwQhbmCPp6mPA_C-5l5lJggyEg.B0DbxNEzz3DxRJtShiiBHDLzLQSCFDo_Bp6c-bcMDiog.JPEG.jws790103/20230925%EF%BC%BF080218.jpg",
         "https://blogfiles.pstatic.net/MjAyMzA5MjVfMjAz/MDAxNjk1NjQ0MzI4OTA5.Kd4VzqHhhrgby7rCA1iPdBX6f_k2DPEBnlRdOWD-kPgg.U0C1lmlKVMZMA4hhhs69nolZwCZ4Plme4KVbNfhezhkg.JPEG.jws790103/20230925%EF%BC%BF081103.jpg",
         "https://blogfiles.pstatic.net/MjAyMzA5MjVfMTg3/MDAxNjk1NjQ0MzI4OTk2.faiqny7Fl82Nnc3cJj85xa_MSBjYR3BStKeHw2bjYTwg.7Z8w0lDO9Uhjr8QTGwA0az_UZhN9haHocbYWgEyBO9gg.JPEG.jws790103/20230925%EF%BC%BF081141.jpg",

--- a/test/results/naverwebtoon.py
+++ b/test/results/naverwebtoon.py
@@ -101,7 +101,7 @@ __tests__ = (
     "#category": ("", "naverwebtoon", "comic"),
     "#class"   : naverwebtoon.NaverwebtoonComicExtractor,
     "#range"   : "1",
-    "#urls"    : "https://comic.naver.com/challenge/detail?titleId=765124&no=1",
+    "#results" : "https://comic.naver.com/challenge/detail?titleId=765124&no=1",
 },
 
 {

--- a/test/results/nekohouse.py
+++ b/test/results/nekohouse.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"     : "https://nekohouse.su/fantia/user/319092/post/3163233",
     "#class"   : nekohouse.NekohousePostExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://nekohouse.su/data/b2/ca/b2ca86189cda7408d75c36d850ca6394c089786d46c6dd0c90b4a2e17e07774f.jpg",
         "https://nekohouse.su/data/2e/cf/2ecfd1a04affa35c147bb43d626d6149c2c3f9a9fb7df1659a40c8de1b3e09e5.jpg",
         "https://nekohouse.su/data/9a/ed/9aed4b879023b761882c7c11ce74a3ee51a22487e2c77df0bfabed7c5a73cbe5.jpg",
@@ -39,7 +39,7 @@ __tests__ = (
     "#comment" : "attachment / video",
     "#class"   : nekohouse.NekohousePostExtractor,
     "#range"   : "6",
-    "#urls"    : (
+    "#results" : (
         "https://nekohouse.su/data/f9/4c/f94ca55a329604bec63536828a36fd2b455aec03ffb3657e25c0b405d8484823.mp4",
     ),
 

--- a/test/results/newgrounds.py
+++ b/test/results/newgrounds.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://www.newgrounds.com/art/view/tomfulp/ryu-is-hawt",
     "#category": ("", "newgrounds", "image"),
     "#class"   : newgrounds.NewgroundsImageExtractor,
-    "#urls"        : "https://art.ngfiles.com/images/1993000/1993615_4474_tomfulp_ryu-is-hawt.44f81090378ae9c257a5e46a8e17cc4d.gif?f1695674895",
+    "#results"     : "https://art.ngfiles.com/images/1993000/1993615_4474_tomfulp_ryu-is-hawt.44f81090378ae9c257a5e46a8e17cc4d.gif?f1695674895",
     "#sha1_content": "8f395e08333eb2457ba8d8b715238f8910221365",
 
     "artist"     : ["tomfulp"],
@@ -39,7 +39,7 @@ __tests__ = (
     "#url"     : "https://art.ngfiles.com/images/0/94_tomfulp_ryu-is-hawt.gif",
     "#category": ("", "newgrounds", "image"),
     "#class"   : newgrounds.NewgroundsImageExtractor,
-    "#urls"    : "https://art.ngfiles.com/images/1993000/1993615_4474_tomfulp_ryu-is-hawt.44f81090378ae9c257a5e46a8e17cc4d.gif?f1695674895",
+    "#results" : "https://art.ngfiles.com/images/1993000/1993615_4474_tomfulp_ryu-is-hawt.44f81090378ae9c257a5e46a8e17cc4d.gif?f1695674895",
 },
 
 {
@@ -47,7 +47,7 @@ __tests__ = (
     "#comment" : "embedded file in 'comments' (#1033)",
     "#category": ("", "newgrounds", "image"),
     "#class"   : newgrounds.NewgroundsImageExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://art.ngfiles.com/images/1438000/1438673_sailoryon_yon-dream-buster.jpg?f1601058173",
         "https://art.ngfiles.com/comments/172000/iu_172374_7112211.jpg",
     ),
@@ -59,7 +59,7 @@ __tests__ = (
     "#category": ("", "newgrounds", "image"),
     "#class"   : newgrounds.NewgroundsImageExtractor,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://art.ngfiles.com/images/5091000/5091275_45067_zedrinbot_untitled-5091275.0a9d27ed2bc265a7e89478ed6ad6f86f.gif?f1696187399",
         "https://art.ngfiles.com/images/5091000/5091275_45071_zedrinbot_untitled-5091275.6fdc62eaef43528fb1c9bda624d30a3d.gif?f1696187436",
         "https://art.ngfiles.com/images/5091000/5091275_45070_zedrinbot_untitled-5091275.0d7334746374465bd448908b88d1f810.gif?f1696187434",
@@ -74,7 +74,7 @@ __tests__ = (
     "#category": ("", "newgrounds", "image"),
     "#class"   : newgrounds.NewgroundsImageExtractor,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://art.ngfiles.com/images/5009000/5009916_14628_zedrinbot_nazrin-tanlines.265f7b6beec5855a349e2646e90cbc01.png?f1695698131",
         "https://art.ngfiles.com/images/5009000/5009916_14632_zedrinbot_nazrin-tanlines.40bd62fbf5875806cda6b004b348114a.png?f1695727318",
         "https://art.ngfiles.com/images/5009000/5009916_14634_zedrinbot_nazrin-tanlines.40bd62fbf5875806cda6b004b348114a.png?f1695727321",
@@ -89,7 +89,7 @@ __tests__ = (
     "#comment" : "extra files in 'imageData' block (#4642)",
     "#category": ("", "newgrounds", "image"),
     "#class"   : newgrounds.NewgroundsImageExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://art.ngfiles.com/images/5127000/5127150_93307_bacun_kill-la-kill-10th-anniversary.61adfe309bec342f9db55fd44397235b.png?f1697310027",
         "https://art.ngfiles.com/images/5127000/5127150_94250_bacun_kill-la-kill-10th-anniversary.64fdf525fa38c1ab34defac4b354bc7a.webp?f1697332147",
     ),
@@ -99,7 +99,7 @@ __tests__ = (
     "#url"     : "https://www.newgrounds.com/art/view/sockdotclip/trickin-treats",
     "#comment" : "extra files in comment section as '<img src=' (#6253)",
     "#class"   : newgrounds.NewgroundsImageExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://art.ngfiles.com/images/2811000/2811344_sockdotclip_trickin-treats.png?f1667246310",
         "https://art.ngfiles.com/comments/788000/iu_788899_10504416.webp",
         "https://art.ngfiles.com/comments/788000/iu_788901_10504416.webp",
@@ -123,7 +123,7 @@ __tests__ = (
     "#comment" : "video",
     "#category": ("", "newgrounds", "media"),
     "#class"   : newgrounds.NewgroundsMediaExtractor,
-    "#urls"    : "https://uploads.ungrounded.net/alternate/564000/564957_alternate_31.mp4?1359712249",
+    "#results" : "https://uploads.ungrounded.net/alternate/564000/564957_alternate_31.mp4?1359712249",
 
     "artist"     : [
         "kickinthehead",
@@ -152,7 +152,7 @@ __tests__ = (
     "#category": ("", "newgrounds", "media"),
     "#class"   : newgrounds.NewgroundsMediaExtractor,
     "#options" : {"format": ["mkv", "mov", 1080]},
-    "#urls"    : "https://uploads.ungrounded.net/alternate/564000/564957_alternate_31.mkv?1359712249",
+    "#results" : "https://uploads.ungrounded.net/alternate/564000/564957_alternate_31.mkv?1359712249",
 },
 
 {
@@ -160,7 +160,7 @@ __tests__ = (
     "#category": ("", "newgrounds", "media"),
     "#class"   : newgrounds.NewgroundsMediaExtractor,
     "#options" : {"format": "720p"},
-    "#urls"    : "https://uploads.ungrounded.net/alternate/564000/564957_alternate_31.720p.mp4?1359712249",
+    "#results" : "https://uploads.ungrounded.net/alternate/564000/564957_alternate_31.720p.mp4?1359712249",
 },
 
 {
@@ -217,7 +217,7 @@ Also wanna give a big shout-out to by by Zachary (Zachary.newgrounds.com) for pr
     "#comment" : "flash animation (#1257)",
     "#category": ("", "newgrounds", "media"),
     "#class"   : newgrounds.NewgroundsMediaExtractor,
-    "#urls"    : "https://uploads.ungrounded.net/161000/161181_ddautta_mask__550x281_.swf",
+    "#results" : "https://uploads.ungrounded.net/161000/161181_ddautta_mask__550x281_.swf",
 
     "type": "movie",
 },
@@ -245,7 +245,7 @@ Also wanna give a big shout-out to by by Zachary (Zachary.newgrounds.com) for pr
     "#comment" : "flash game",
     "#category": ("", "newgrounds", "media"),
     "#class"   : newgrounds.NewgroundsMediaExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://uploads.ungrounded.net/829000/829032_picovsbeardx.swf",
         "https://uploads.ungrounded.net/tmp/img/521000/iu_521265_5431202.gif",
     ),
@@ -338,14 +338,14 @@ Also wanna give a big shout-out to by by Zachary (Zachary.newgrounds.com) for pr
 {
     "#url"     : "https://tomfulp.newgrounds.com",
     "#class"   : newgrounds.NewgroundsUserExtractor,
-    "#urls"    : "https://tomfulp.newgrounds.com/art",
+    "#results" : "https://tomfulp.newgrounds.com/art",
 },
 
 {
     "#url"     : "https://tomfulp.newgrounds.com",
     "#class"   : newgrounds.NewgroundsUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : (
+    "#results" : (
         "https://tomfulp.newgrounds.com/art",
         "https://tomfulp.newgrounds.com/audio",
         "https://tomfulp.newgrounds.com/games",

--- a/test/results/nijie.py
+++ b/test/results/nijie.py
@@ -14,7 +14,7 @@ __tests__ = (
     "#url"     : "https://nijie.info/members.php?id=44",
     "#category": ("Nijie", "nijie", "user"),
     "#class"   : nijie.NijieUserExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://nijie.info/members_illust.php?id=44",
         "https://nijie.info/members_dojin.php?id=44",
     ),
@@ -24,7 +24,7 @@ __tests__ = (
     "#url"     : "https://nijie.info/members_illust.php?id=44",
     "#category": ("Nijie", "nijie", "illustration"),
     "#class"   : nijie.NijieIllustrationExtractor,
-    "#urls": (
+    "#results": (
         "https://pic.nijie.net/__s4__/d7b5d8b576a90f3688cfe6bfa6ebb678817ecb4c19f118e187e0f039c81b2e5d0b6c2edfe359d9f65b457507bf9ae807801a0ac27b9cf06ee94e1cb848c75d2f31353acc3197dff04f537d70a7cb6b8782f6f0635de3f3d522e57827.jpg",
         "https://pic.nijie.net/__s4__/d7e2d9b124a95933ddc4e5baadbcb62b2a0ce7c6163dadac1d49c57e8da5d113398f3170da7835f03c897d9d6a9993d8fa40036a5209508611a305280cd684b33ca600f8160ee0d958b7c7f49972e4f4c650b8d58fff493a032d25f8.jpg",
     ),
@@ -101,7 +101,7 @@ __tests__ = (
     "#url"     : "https://nijie.info/view.php?id=70720",
     "#category": ("Nijie", "nijie", "image"),
     "#class"   : nijie.NijieImageExtractor,
-    "#urls"         : "https://pic.nijie.net/__s4__/d7e2d9b124a95933ddc4e5baadbcb62b2a0ce7c6163dadac1d49c57e8da5d113398f3170da7835f03c897d9d6a9993d8fa40036a5209508611a305280cd684b33ca600f8160ee0d958b7c7f49972e4f4c650b8d58fff493a032d25f8.jpg",
+    "#results"      : "https://pic.nijie.net/__s4__/d7e2d9b124a95933ddc4e5baadbcb62b2a0ce7c6163dadac1d49c57e8da5d113398f3170da7835f03c897d9d6a9993d8fa40036a5209508611a305280cd684b33ca600f8160ee0d958b7c7f49972e4f4c650b8d58fff493a032d25f8.jpg",
     "#sha1_content" : "d85e3ea896ed5e4da0bca2390ad310a4df716ca6",
 
     "artist_id"  : 44,
@@ -133,7 +133,7 @@ __tests__ = (
     "#comment" : "'view_side_dojin' thumbnails (#5049)",
     "#category": ("Nijie", "nijie", "image"),
     "#class"   : nijie.NijieImageExtractor,
-    "#urls"    : "https://pic.nijie.net/__s4__/d7b5d9b470fa0d368bcbb0bda4bae2797380288fb3a6f2d9aa1899530bbc0453912f2397ee9a37dbbd992b5bbde36f86061910e06961837c0ae7629006732ef8581a512a0e0b454ca050fa793340367fbef201687f1b8cdb2692898b.jpg",
+    "#results" : "https://pic.nijie.net/__s4__/d7b5d9b470fa0d368bcbb0bda4bae2797380288fb3a6f2d9aa1899530bbc0453912f2397ee9a37dbbd992b5bbde36f86061910e06961837c0ae7629006732ef8581a512a0e0b454ca050fa793340367fbef201687f1b8cdb2692898b.jpg",
 },
 
 {
@@ -141,7 +141,7 @@ __tests__ = (
     "#comment" : "video (#5707)",
     "#category": ("Nijie", "nijie", "image"),
     "#class"   : nijie.NijieImageExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://pic.nijie.net/__s4__/d7b884ee71f90f358fcfe0bbf2e7b57ac1b72bd5df705d984997b3d47968e387b4d2e33c04faa793c9bb26f3f005eb5f875b440fcabb36f02d811203325ce520aacc1581c0ea361906bd6877031942a2a340d44ff9ba3d9c23950d44.mp4",
         "https://pic.nijie.net/__s4__/d7e685e777ae0f308ecaeabda0e8e32c4a0873467846be7078716328f9b105bfc278d968db43d2707e577c63c231fb1a4999570823c460f18ee35b790f6e1c4a4c01a05a8c3260c2cd3b9f77810e5a1b2a22755f279f47cf86e75733.jpg",
         "https://pic.nijie.net/__s4__/d7b38cee78f80c678acae3bef2b9e32c0fd196fdafaed57c041390ac33dd8f23b3236a48d9d41c6081ce7ca79840caa7deacc0120a0dc516210e2925c954d79c08e94bb9c0f7c572bd174336f64e6924721a2727078df5ad48e77b1b.jpg",

--- a/test/results/noop.py
+++ b/test/results/noop.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"     : "noop",
     "#class"   : noop.NoopExtractor,
-    "#urls"    : (),
+    "#results" : (),
     "#count"   : 0,
 },
 

--- a/test/results/nozomi.py
+++ b/test/results/nozomi.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://nozomi.la/post/3649262.html",
     "#category": ("", "nozomi", "post"),
     "#class"   : nozomi.NozomiPostExtractor,
-    "#urls"        : "https://w.gold-usergeneratedcontent.net/2/15/aaa9f7c632cde1e1a5baaff3fb6a6d857ec73df7fdc5cf5a358caf604bf73152.webp",
+    "#results"     : "https://w.gold-usergeneratedcontent.net/2/15/aaa9f7c632cde1e1a5baaff3fb6a6d857ec73df7fdc5cf5a358caf604bf73152.webp",
     "#sha1_content": "6d62c4a7fea50c0a89d499603c4e7a2b4b9bffa8",
 
     "artist"   : ["hammer (sunset beach)"],
@@ -36,7 +36,7 @@ __tests__ = (
     "#comment" : "multiple images per post",
     "#category": ("", "nozomi", "post"),
     "#class"   : nozomi.NozomiPostExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://w.gold-usergeneratedcontent.net/3/94/085e55e355808c03dedbe74fe44db1c07435e071952e8b925a3dfe5ec3278943.webp",
         "https://w.gold-usergeneratedcontent.net/e/78/0fb5675f47e981650ab7a549cc8d90230ab0d249f35247258f6a7ceb81dd578e.webp",
         "https://w.gold-usergeneratedcontent.net/3/68/f3cde060f8e9047171bebb70e62947375ef6bdc0160f2f37ea4d5d25ebfde683.webp",
@@ -61,7 +61,7 @@ __tests__ = (
     "#comment" : "gif",
     "#category": ("", "nozomi", "post"),
     "#class"   : nozomi.NozomiPostExtractor,
-    "#urls"        : "https://g.gold-usergeneratedcontent.net/a/f0/d1b06469e00d72e4f6346209c149db459d76b58a074416c260ed93cc31fa9f0a.gif",
+    "#results"     : "https://g.gold-usergeneratedcontent.net/a/f0/d1b06469e00d72e4f6346209c149db459d76b58a074416c260ed93cc31fa9f0a.gif",
     "#sha1_content": "952efb78252bbc9fb56df2e8fafb68d5e6364181",
 },
 
@@ -70,7 +70,7 @@ __tests__ = (
     "#comment" : "video",
     "#category": ("", "nozomi", "post"),
     "#class"   : nozomi.NozomiPostExtractor,
-    "#urls"        : "https://v.gold-usergeneratedcontent.net/d/0e/ff88398862669783691b31519f2bea3a35c24b6e62e3ba2d89b4409e41c660ed.webm",
+    "#results"     : "https://v.gold-usergeneratedcontent.net/d/0e/ff88398862669783691b31519f2bea3a35c24b6e62e3ba2d89b4409e41c660ed.webm",
     "#sha1_content": "57065e6c16da7b1c7098a63b36fb0c6c6f1b9bca",
 },
 

--- a/test/results/nsfwalbum.py
+++ b/test/results/nsfwalbum.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#category": ("", "nsfwalbum", "album"),
     "#class"   : nsfwalbum.NsfwalbumAlbumExtractor,
     "#range"        : "1-5",
-    "#urls"         : (
+    "#results"      : (
         "https://img70.imgspice.com/i/05457/mio2bu5xbrxe.jpg",
         "https://img70.imgspice.com/i/05457/zgpxa8kr4h1d.jpg",
         "https://img70.imgspice.com/i/05457/3379nxsm9lx8.jpg",

--- a/test/results/paheal.py
+++ b/test/results/paheal.py
@@ -64,7 +64,7 @@ __tests__ = (
     "#url"     : "https://rule34.paheal.net/post/view/481609",
     "#category": ("shimmie2", "paheal", "post"),
     "#class"   : paheal.PahealPostExtractor,
-    "#urls"        : "https://r34i.paheal-cdn.net/bb/dc/bbdc1c33410c2cdce7556c7990be26b7",
+    "#results"     : "https://r34i.paheal-cdn.net/bb/dc/bbdc1c33410c2cdce7556c7990be26b7",
     "#sha1_content": "7b924bcf150b352ac75c9d281d061e174c851a11",
 
     "date"     : "dt:2010-06-17 15:40:23",
@@ -101,7 +101,7 @@ __tests__ = (
     "#comment" : "video",
     "#category": ("shimmie2", "paheal", "post"),
     "#class"   : paheal.PahealPostExtractor,
-    "#urls"    : "https://r34i.paheal-cdn.net/76/29/7629fc0ff77e32637dde5bf4f992b2cb",
+    "#results" : "https://r34i.paheal-cdn.net/76/29/7629fc0ff77e32637dde5bf4f992b2cb",
 
     "date"     : "dt:2020-09-06 01:59:03",
     "duration" : 30.0,

--- a/test/results/pexels.py
+++ b/test/results/pexels.py
@@ -107,7 +107,7 @@ __tests__ = (
 {
     "#url"     : "https://www.pexels.com/photo/sun-shining-between-the-trees-in-the-forest-onto-an-asphalt-road-17213600/",
     "#class"   : pexels.PexelsImageExtractor,
-    "#urls"    : "https://images.pexels.com/photos/17213600/pexels-photo-17213600.jpeg",
+    "#results" : "https://images.pexels.com/photos/17213600/pexels-photo-17213600.jpeg",
 },
 
 )

--- a/test/results/philomena.py
+++ b/test/results/philomena.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#comment" : "'view_url' yields 404 (#6922)",
     "#category": ("philomena", "manebooru.art", "post"),
     "#class"   : philomena.PhilomenaPostExtractor,
-    "#urls"        : "https://static.manebooru.art/img/view/2020/10/27/307071.png",
+    "#results"     : "https://static.manebooru.art/img/view/2020/10/27/307071.png",
     "#sha1_content": "82c21bfb2675449893fa4b2546546f404019b3c8",
 
     "date"     : "dt:2020-10-27 11:58:40"
@@ -23,7 +23,7 @@ __tests__ = (
     "#url"     : "philomena:https://ponerpics.org/images/1",
     "#category": ("philomena", "ponerpics.org", "post"),
     "#class"   : philomena.PhilomenaPostExtractor,
-    "#urls"    : "https://ponerpics.org/img/view/2012/1/2/1.png",
+    "#results" : "https://ponerpics.org/img/view/2012/1/2/1.png",
 
     "date"     : "dt:2012-01-02 03:12:33"
 },

--- a/test/results/pictoa.py
+++ b/test/results/pictoa.py
@@ -35,7 +35,7 @@ __tests__ = (
     "#url"    : "https://it.pictoa.com/albums/carl-virkus-149024.html",
     "#comment": "null tags",
     "#class"  : pictoa.PictoaAlbumExtractor,
-    "#urls"   : "https://www.pictoa.com/albums/carl-virkus-149024/2221031.html",
+    "#results": "https://www.pictoa.com/albums/carl-virkus-149024/2221031.html",
 
     "album_id"   : "149024",
     "album_title": "Carl Virkus",
@@ -45,7 +45,7 @@ __tests__ = (
 {
     "#url"  : "https://www.pictoa.com/albums/anna-kendrick-showing-cleavage-at-the-56th-annual-grammy-awards-3233172/75206264.html",
     "#class": pictoa.PictoaImageExtractor,
-    "#urls" : "https://s1.pictoa.com/media/galleries/168/930/168930594a8750dfd3e/3233172594a8759dcc3a.jpg",
+    "#results": "https://s1.pictoa.com/media/galleries/168/930/168930594a8750dfd3e/3233172594a8759dcc3a.jpg",
 
     "album_id"   : "3233172",
     "album_title": "Anna Kendrick showing cleavage at the 56th Annual GRAMMY Awards",
@@ -58,7 +58,7 @@ __tests__ = (
 {
     "#url"  : "https://nl.pictoa.com/albums/kandi-barbour-3840809/94038192.html",
     "#class": pictoa.PictoaImageExtractor,
-    "#urls"        : "https://s2.pictoa.com/media/galleries/294/452/29445260009fa5b68e4/384080960009fb51e389.jpg",
+    "#results"     : "https://s2.pictoa.com/media/galleries/294/452/29445260009fa5b68e4/384080960009fb51e389.jpg",
     "#sha1_content": "152595069016da89565eb3d8e73df835afd22e2c",
 
     "album_id"   : "3840809",

--- a/test/results/piczel.py
+++ b/test/results/piczel.py
@@ -18,7 +18,7 @@ __tests__ = (
 {
     "#url"  : "https://piczel.tv/gallery/Lulena/1114",
     "#class": piczel.PiczelFolderExtractor,
-    "#urls" : (
+    "#results": (
         "https://piczel.tv/static/uploads/gallery_image/32920/image/11194/1544126403-Lulena.png",
         "https://piczel.tv/static/uploads/gallery_image/32920/image/8008/1533616260-Lulena.png",
         "https://piczel.tv/static/uploads/plain_image/32920/image/3761/3761-Lulena.png",
@@ -34,7 +34,7 @@ __tests__ = (
 {
     "#url"  : "https://piczel.tv/gallery/image/7807",
     "#class": piczel.PiczelImageExtractor,
-    "#urls"        : "https://piczel.tv/static/uploads/gallery_image/32920/image/7807/1532236438-Lulena.png",
+    "#results"     : "https://piczel.tv/static/uploads/gallery_image/32920/image/7807/1532236438-Lulena.png",
     "#sha1_content": "df9a053a24234474a19bce2b7e27e0dec23bff87",
 
     "count"           : 1,
@@ -66,7 +66,7 @@ __tests__ = (
     "#url"    : "https://piczel.tv/gallery/image/8008",
     "#comment": "multi",
     "#class"  : piczel.PiczelImageExtractor,
-    "#urls"   : (
+    "#results": (
         "https://piczel.tv/static/uploads/gallery_image/32920/image/8008/1533616260-Lulena.png",
         "https://piczel.tv/static/uploads/plain_image/32920/image/3761/3761-Lulena.png",
         "https://piczel.tv/static/uploads/plain_image/32920/image/3762/3762-Lulena.png",

--- a/test/results/pidgiwiki.py
+++ b/test/results/pidgiwiki.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://www.pidgi.net/wiki/File:Key_art_-_Fight_Knight.png",
     "#category": ("wikimedia", "pidgiwiki", "file"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#urls"    : "https://cdn.pidgi.net/images/0/0c/Key_art_-_Fight_Knight.png",
+    "#results" : "https://cdn.pidgi.net/images/0/0c/Key_art_-_Fight_Knight.png",
 },
 
 {

--- a/test/results/pinterest.py
+++ b/test/results/pinterest.py
@@ -32,7 +32,7 @@ __tests__ = (
     "#url"     : "https://jp.pinterest.com/pin/858146904010573850/",
     "#comment" : "story pin with images",
     "#class"   : pinterest.PinterestPinExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://i.pinimg.com/originals/0f/b0/8c/0fb08c519067dd263a1fcfecea775450.jpg",
         "https://i.pinimg.com/originals/2f/27/f3/2f27f3eb781b107ce58bf588c12a12b7.jpg",
         "https://i.pinimg.com/originals/55/fd/df/55fddf8d26aa0d96071af52ac6a0c25f.jpg",
@@ -43,7 +43,7 @@ __tests__ = (
     "#url"     : "https://www.pinterest.com/pin/63824519713049795/",
     "#comment" : "story pin with video (#6188)",
     "#class"   : pinterest.PinterestPinExtractor,
-    "#urls"    : "ytdl:https://v1.pinimg.com/videos/iht/hls/7a/b0/cc/7ab0cc56dcbfc1508b8d650af7b0a593.m3u8",
+    "#results" : "ytdl:https://v1.pinimg.com/videos/iht/hls/7a/b0/cc/7ab0cc56dcbfc1508b8d650af7b0a593.m3u8",
 
     "extension"     : "mp4",
     "_ytdl_manifest": "hls",
@@ -54,7 +54,7 @@ __tests__ = (
     "#comment" : "story pin with audio (#6188)",
     "#class"   : pinterest.PinterestPinExtractor,
     "#range"   : "2",
-    "#urls"    : "https://v1.pinimg.com/audios/mp3/5d/37/74/5d37749bde03855c1292f8869c8d9387.mp3",
+    "#results" : "https://v1.pinimg.com/audios/mp3/5d/37/74/5d37749bde03855c1292f8869c8d9387.mp3",
 
     "extension": "mp3",
 },
@@ -64,21 +64,21 @@ __tests__ = (
     "#comment" : "story pin with text",
     "#class"   : pinterest.PinterestPinExtractor,
     "#range"   : "2",
-    "#urls"    : "text:Everskies character+outfits i made",
+    "#results" : "text:Everskies character+outfits i made",
 },
 
 {
     "#url"     : "https://www.pinterest.com/pin/1025272671423645004/",
     "#comment" : "story pin with 'story_pin_static_sticker_block' blocks",
     "#class"   : pinterest.PinterestPinExtractor,
-    "#urls"    : "https://i.pinimg.com/originals/70/ab/31/70ab31654b2329e2ec74a39adf7ee683.jpg",
+    "#results" : "https://i.pinimg.com/originals/70/ab/31/70ab31654b2329e2ec74a39adf7ee683.jpg",
 },
 
 {
     "#url"     : "https://www.pinterest.com/pin/777856166916298367",
     "#comment" : "story pin with 'story_pin_product_sticker_block' blocks (#7563)",
     "#class"   : pinterest.PinterestPinExtractor,
-    "#urls"    : "https://i.pinimg.com/originals/3e/0a/2e/3e0a2e6c1173866c530c8ffe18d08b9f.jpg",
+    "#results" : "https://i.pinimg.com/originals/3e/0a/2e/3e0a2e6c1173866c530c8ffe18d08b9f.jpg",
 },
 
 {
@@ -91,7 +91,7 @@ __tests__ = (
 {
     "#url"     : "https://www.pinterest.com/g1952849/test-/",
     "#class"   : pinterest.PinterestBoardExtractor,
-    "#urls"    : "https://i.pinimg.com/originals/d4/f4/7f/d4f47fa2fce4c4c28475af5d94972904.jpg",
+    "#results" : "https://i.pinimg.com/originals/d4/f4/7f/d4f47fa2fce4c4c28475af5d94972904.jpg",
 },
 
 {
@@ -109,7 +109,7 @@ __tests__ = (
     "#category": ("", "pinterest", "board"),
     "#class"   : pinterest.PinterestBoardExtractor,
     "#options" : {"sections": True},
-    "#urls"    : "https://www.pinterest.jp/gdldev/bname/id:5345901183739414095",
+    "#results" : "https://www.pinterest.jp/gdldev/bname/id:5345901183739414095",
 },
 
 {

--- a/test/results/pinterest.py
+++ b/test/results/pinterest.py
@@ -13,6 +13,7 @@ __tests__ = (
     "#url"     : "https://www.pinterest.com/pin/858146903966145189/",
     "#category": ("", "pinterest", "pin"),
     "#class"   : pinterest.PinterestPinExtractor,
+    "#results" : "https://i.pinimg.com/originals/d4/f4/7f/d4f47fa2fce4c4c28475af5d94972904.jpg",
     "#sha1_url"    : "afb3c26719e3a530bb0e871c480882a801a4e8a5",
     "#sha1_content": [
         "4c435a66f6bb82bb681db2ecc888f76cf6c5f9ca",
@@ -79,6 +80,17 @@ __tests__ = (
     "#comment" : "story pin with 'story_pin_product_sticker_block' blocks (#7563)",
     "#class"   : pinterest.PinterestPinExtractor,
     "#results" : "https://i.pinimg.com/originals/3e/0a/2e/3e0a2e6c1173866c530c8ffe18d08b9f.jpg",
+    "#exception": exception.NotFoundError,
+},
+
+{
+    "#url"     : "https://pinterest.com/pin/725220346239561090/",
+    "#comment" : "stripped 'description' & 'closeup_unified_description' (#4335)",
+    "#class"   : pinterest.PinterestPinExtractor,
+    "#results" : "https://i.pinimg.com/originals/66/a3/9a/66a39a10c015df67b85481105fb3a81e.jpg",
+
+    "description": "",
+    "closeup_unified_description": "",
 },
 
 {

--- a/test/results/pixeldrain.py
+++ b/test/results/pixeldrain.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://pixeldrain.com/u/jW9E6s4h",
     "#category": ("", "pixeldrain", "file"),
     "#class"   : pixeldrain.PixeldrainFileExtractor,
-    "#urls"        : "https://pixeldrain.com/api/file/jW9E6s4h?download",
+    "#results"     : "https://pixeldrain.com/api/file/jW9E6s4h?download",
     "#sha1_content": "0c8768055e4e20e7c7259608b67799171b691140",
 
     "abuse_reporter_name" : "",
@@ -49,7 +49,7 @@ __tests__ = (
     "#url"     : "https://pixeldrain.com/u/yEK1n2Qc",
     "#category": ("", "pixeldrain", "file"),
     "#class"   : pixeldrain.PixeldrainFileExtractor,
-    "#urls"        : "https://pixeldrain.com/api/file/yEK1n2Qc?download",
+    "#results"     : "https://pixeldrain.com/api/file/yEK1n2Qc?download",
     "#sha1_content": "08463261191d403de2133d829060050d8b04609f",
 
     "date"       : "dt:2023-11-22 16:38:04",
@@ -67,7 +67,7 @@ __tests__ = (
     "#url"     : "https://pixeldrain.com/l/zQ7XpWfM",
     "#category": ("", "pixeldrain", "album"),
     "#class"   : pixeldrain.PixeldrainAlbumExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://pixeldrain.com/api/file/yEK1n2Qc?download",
         "https://pixeldrain.com/api/file/jW9E6s4h?download",
     ),
@@ -93,7 +93,7 @@ __tests__ = (
     "#url"     : "https://pixeldrain.com/l/zQ7XpWfM#item=0",
     "#category": ("", "pixeldrain", "album"),
     "#class"   : pixeldrain.PixeldrainAlbumExtractor,
-    "#urls"        : "https://pixeldrain.com/api/file/jW9E6s4h?download",
+    "#results"     : "https://pixeldrain.com/api/file/jW9E6s4h?download",
     "#sha1_content": "0c8768055e4e20e7c7259608b67799171b691140",
 },
 
@@ -101,7 +101,7 @@ __tests__ = (
     "#url"     : "https://pixeldrain.com/d/8xz8hcYJ",
     "#category": ("", "pixeldrain", "folder"),
     "#class"   : pixeldrain.PixeldrainFolderExtractor,
-    "#urls"        : "https://pixeldrain.com/api/filesystem/8xz8hcYJ?attach",
+    "#results"     : "https://pixeldrain.com/api/filesystem/8xz8hcYJ?attach",
     "#sha1_content": "edfea851cad717f5643cb94ac04b32335611acf2",
 
     "date"       : "dt:2025-05-19 15:27:54",
@@ -121,7 +121,7 @@ __tests__ = (
     "#url"     : "https://pixeldrain.com/api/filesystem/8xz8hcYJ",
     "#category": ("", "pixeldrain", "folder"),
     "#class"   : pixeldrain.PixeldrainFolderExtractor,
-    "#urls"        : "https://pixeldrain.com/api/filesystem/8xz8hcYJ?attach",
+    "#results"     : "https://pixeldrain.com/api/filesystem/8xz8hcYJ?attach",
     "#sha1_content": "edfea851cad717f5643cb94ac04b32335611acf2",
 
     "date"       : "dt:2025-05-19 15:27:54",
@@ -142,7 +142,7 @@ __tests__ = (
     "#comment" : "dir with file",
     "#category": ("", "pixeldrain", "folder"),
     "#class"   : pixeldrain.PixeldrainFolderExtractor,
-    "#urls"    : ("https://pixeldrain.com/api/filesystem/DkdR6QRh/test.mp4?attach"),
+    "#results" : ("https://pixeldrain.com/api/filesystem/DkdR6QRh/test.mp4?attach"),
 
     "id": "DkdR6QRh",
 },
@@ -161,7 +161,7 @@ __tests__ = (
     "#comment" : "dir with subdir and files",
     "#category": ("", "pixeldrain", "folder"),
     "#class"   : pixeldrain.PixeldrainFolderExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://pixeldrain.com/api/filesystem/qTnZkhCJ/test1.mp4?attach",
         "https://pixeldrain.com/api/filesystem/qTnZkhCJ/test2.mp4?attach",
     ),
@@ -174,7 +174,7 @@ __tests__ = (
     "#comment" : "file in subdir",
     "#category": ("", "pixeldrain", "folder"),
     "#class"   : pixeldrain.PixeldrainFolderExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://pixeldrain.com/api/filesystem/qTnZkhCJ/subdir/test3.mp4?attach",
     ),
 

--- a/test/results/pixiv.py
+++ b/test/results/pixiv.py
@@ -165,7 +165,7 @@ __tests__ = (
     "#comment" : "ugoira",
     "#category": ("", "pixiv", "work"),
     "#class"   : pixiv.PixivWorkExtractor,
-    "#urls"    : "https://i.pximg.net/img-zip-ugoira/img/2018/01/15/13/24/48/66806629_ugoira1920x1080.zip",
+    "#results" : "https://i.pximg.net/img-zip-ugoira/img/2018/01/15/13/24/48/66806629_ugoira1920x1080.zip",
 
     "frames"  : list,
     "date"    : "dt:2018-01-14 15:06:08",
@@ -178,14 +178,14 @@ __tests__ = (
     "#category": ("", "pixiv", "work"),
     "#class"   : pixiv.PixivWorkExtractor,
     "#options" : {"ugoira": "original"},
-    "#urls"    : [
+    "#results" : (
         "https://i.pximg.net/img-original/img/2022/09/04/23/54/19/101003492_ugoira0.png",
         "https://i.pximg.net/img-original/img/2022/09/04/23/54/19/101003492_ugoira1.png",
         "https://i.pximg.net/img-original/img/2022/09/04/23/54/19/101003492_ugoira2.png",
         "https://i.pximg.net/img-original/img/2022/09/04/23/54/19/101003492_ugoira3.png",
         "https://i.pximg.net/img-original/img/2022/09/04/23/54/19/101003492_ugoira4.png",
         "https://i.pximg.net/img-original/img/2022/09/04/23/54/19/101003492_ugoira5.png",
-    ],
+    ),
 
     "frames": list,
 },
@@ -213,7 +213,7 @@ __tests__ = (
     "#comment" : "limit_sanity_level_360.png (#4327, #5180)",
     "#class"   : pixiv.PixivWorkExtractor,
     "#options" : {"sanity": True, "comments": True},
-    "#urls"    : "https://i.pximg.net/img-original/img/2022/11/20/00/00/49/102932581_p0.jpg",
+    "#results" : "https://i.pximg.net/img-original/img/2022/11/20/00/00/49/102932581_p0.jpg",
 
     "caption"       : "Meet a deer .",
     "comment_access_control": 0,
@@ -278,12 +278,12 @@ __tests__ = (
     "#url"     : "https://www.pixiv.net/en/artworks/109487939",
     "#comment" : "R-18 limit_sanity_level_360.png (#4327, #5180)",
     "#class"   : pixiv.PixivWorkExtractor,
-    "#urls"    : [
+    "#results" : (
         "https://i.pximg.net/img-original/img/2023/07/01/00/06/28/109487939_p0.png",
         "https://i.pximg.net/img-original/img/2023/07/01/00/06/28/109487939_p1.png",
         "https://i.pximg.net/img-original/img/2023/07/01/00/06/28/109487939_p2.png",
         "https://i.pximg.net/img-original/img/2023/07/01/00/06/28/109487939_p3.png",
-    ],
+    ),
 },
 
 {
@@ -291,7 +291,7 @@ __tests__ = (
     "#comment" : "Ugoira limit_sanity_level_360.png (#4327 #6297 #7285)",
     "#class"   : pixiv.PixivWorkExtractor,
     "#auth"    : True,
-    "#urls"    : "https://i.pximg.net/img-zip-ugoira/img/2022/12/23/23/36/13/103841583_ugoira1920x1080.zip",
+    "#results" : "https://i.pximg.net/img-zip-ugoira/img/2022/12/23/23/36/13/103841583_ugoira1920x1080.zip",
 },
 
 {
@@ -376,7 +376,7 @@ __tests__ = (
 {
     "#url"     : "https://www.pixiv.net/en/artworks/unlisted/eE3fTYaROT9IsZmep386",
     "#class"   : pixiv.PixivUnlistedExtractor,
-    "#urls"    : "https://i.pximg.net/img-original/img/2020/10/15/00/46/12/85017704-149014193e4d3e23a6b8bd5e38b51ed4_p0.png",
+    "#results" : "https://i.pximg.net/img-original/img/2020/10/15/00/46/12/85017704-149014193e4d3e23a6b8bd5e38b51ed4_p0.png",
 
     "id"         : 85017704,
     "id_unlisted": "eE3fTYaROT9IsZmep386",
@@ -386,26 +386,26 @@ __tests__ = (
     "#url"     : "https://www.pixiv.net/en/users/173530/bookmarks/artworks",
     "#category": ("", "pixiv", "favorite"),
     "#class"   : pixiv.PixivFavoriteExtractor,
-    "#urls"    : [
+    "#results" : (
         "https://i.pximg.net/img-original/img/2008/10/31/17/54/01/2005108_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/09/27/12/22/40/1719386_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/04/15/01/43/46/669358_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/06/19/21/52/15/1005851_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/06/17/22/16/54/994965_p0.jpg",
-    ],
+    ),
 },
 
 {
     "#url"     : "https://www.pixiv.net/bookmark.php?id=173530",
     "#category": ("", "pixiv", "favorite"),
     "#class"   : pixiv.PixivFavoriteExtractor,
-    "#urls"    : [
+    "#results" : (
         "https://i.pximg.net/img-original/img/2008/10/31/17/54/01/2005108_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/09/27/12/22/40/1719386_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/04/15/01/43/46/669358_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/06/19/21/52/15/1005851_p0.jpg",
         "https://i.pximg.net/img-original/img/2008/06/17/22/16/54/994965_p0.jpg",
-    ],
+    ),
 },
 
 {

--- a/test/results/poipiku.py
+++ b/test/results/poipiku.py
@@ -78,7 +78,7 @@ __tests__ = (
     "#comment" : "Warning and no 'Show all' button (#6736)",
     "#category": ("", "poipiku", "post"),
     "#class"   : poipiku.PoipikuPostExtractor,
-    "#urls"    : "https://img-org.poipiku.com/user_img02/001400760/005483268_JdB7sAWpv.jpeg",
+    "#results" : "https://img-org.poipiku.com/user_img02/001400760/005483268_JdB7sAWpv.jpeg",
 
     "count"        : 1,
     "num"          : 1,

--- a/test/results/raddle.py
+++ b/test/results/raddle.py
@@ -69,7 +69,7 @@ __tests__ = (
     "#category": ("postmill", "raddle", "post"),
     "#class"   : postmill.PostmillPostExtractor,
     "#sha1_content": "431e938082c2b59c44888a83cfc711cd1f0e910a",
-    "#urls"        : "https://uploads-cdn.raddle.me/submission_images/30f4cf7d235d40c1daebf6dc2e58bef2a80bec2b5b2dab10f2021ea8e3f29e11.png",
+    "#results"     : "https://uploads-cdn.raddle.me/submission_images/30f4cf7d235d40c1daebf6dc2e58bef2a80bec2b5b2dab10f2021ea8e3f29e11.png",
 },
 
 {
@@ -87,7 +87,7 @@ __tests__ = (
     "#comment" : "Link post",
     "#category": ("postmill", "raddle", "post"),
     "#class"   : postmill.PostmillPostExtractor,
-    "#urls"    : "https://m.youtube.com/watch?v=RFJCA5zcZxI",
+    "#results" : "https://m.youtube.com/watch?v=RFJCA5zcZxI",
     "#count"   : 1,
 },
 

--- a/test/results/realbooru.py
+++ b/test/results/realbooru.py
@@ -19,7 +19,7 @@ __tests__ = (
     "#url"     : "https://realbooru.com/index.php?page=pool&s=show&id=1",
     "#category": ("booru", "realbooru", "pool"),
     "#class"   : realbooru.RealbooruPoolExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://video-cdn.realbooru.com//images/bf/d6/bfd682f338691e5254de796040fcba21.mp4",
         "https://video-cdn.realbooru.com//images/cb/7d/cb7d921673ba99f688031ac554777695.mp4",
         "https://video-cdn.realbooru.com//images/9e/14/9e140edc1cb2e4cc734ba5bdc4870955.mp4",
@@ -30,7 +30,7 @@ __tests__ = (
     "#url"     : "https://realbooru.com/index.php?page=favorites&s=view&id=274",
     "#category": ("booru", "realbooru", "favorite"),
     "#class"   : realbooru.RealbooruFavoriteExtractor,
-    "#urls"    : "https://realbooru.com//images/20/3e/203eefb39f54de049e30ff788a022ac7.jpeg",
+    "#results" : "https://realbooru.com//images/20/3e/203eefb39f54de049e30ff788a022ac7.jpeg",
 },
 
 {
@@ -39,7 +39,7 @@ __tests__ = (
     "#category": ("booru", "realbooru", "post"),
     "#class"   : realbooru.RealbooruPostExtractor,
     "#options"     : {"tags": True},
-    "#urls"        : "https://realbooru.com//images/8a/34/8a345820da989637c21ac013d522bf69.jpeg",
+    "#results"     : "https://realbooru.com//images/8a/34/8a345820da989637c21ac013d522bf69.jpeg",
     "#sha1_content": "f6213e6f25c3cb9e3cfefa6d4b3a78e44b9dea5b",
 
     "created_at"    : "Jan, 18 2024",

--- a/test/results/reddit.py
+++ b/test/results/reddit.py
@@ -184,7 +184,7 @@ __tests__ = (
     "#comment" : "comment embeds (#5366)",
     "#class"   : reddit.RedditSubmissionExtractor,
     "#options" : {"comments": 10},
-    "#urls"    : (
+    "#results" : (
         "https://i.redd.it/ppt5yciyipgb1.jpg",
         "https://i.redd.it/u0ojzd69kpgb1.png",
     ),
@@ -195,7 +195,7 @@ __tests__ = (
     "#comment" : "disabled comment embeds (#6357)",
     "#class"   : reddit.RedditSubmissionExtractor,
     "#options" : {"comments": 10, "embeds": False},
-    "#urls"    : "https://i.redd.it/ppt5yciyipgb1.jpg",
+    "#results" : "https://i.redd.it/ppt5yciyipgb1.jpg",
 },
 
 {
@@ -220,7 +220,7 @@ __tests__ = (
     "#comment" : "preview.redd.it (#4470)",
     "#category": ("", "reddit", "submission"),
     "#class"   : reddit.RedditSubmissionExtractor,
-    "#urls"    : "https://preview.redd.it/u9ud4k6xaf271.jpg?auto=webp&s=19b1334cb4409111cda136c01f7b44c2c42bf9fb",
+    "#results" : "https://preview.redd.it/u9ud4k6xaf271.jpg?auto=webp&s=19b1334cb4409111cda136c01f7b44c2c42bf9fb",
 },
 
 {
@@ -229,7 +229,7 @@ __tests__ = (
     "#category": ("", "reddit", "submission"),
     "#class"   : reddit.RedditSubmissionExtractor,
     "#options" : {"selftext": True, "comments": 0},
-    "#urls"    : (
+    "#results" : (
         "https://www.reddit.com/r/gonewildaudio/s/22pP7vizkx",
         "https://soundgasm.net/u/chuwa/Your-Timid-Neighbor-Asks-You-To-Turn-Your-Music-Down-So-You-Fuck-Her-Stupid",
     ),
@@ -240,7 +240,7 @@ __tests__ = (
     "#comment" : "redgifs embed",
     "#category": ("", "reddit", "submission"),
     "#class"   : reddit.RedditSubmissionExtractor,
-    "#urls"    : "https://redgifs.com/watch/foolishforkedabyssiniancat",
+    "#results" : "https://redgifs.com/watch/foolishforkedabyssiniancat",
 },
 
 {

--- a/test/results/rule34hentai.py
+++ b/test/results/rule34hentai.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://rule34hentai.net/post/list/mizuki_kotora/1",
     "#category": ("shimmie2", "rule34hentai", "tag"),
     "#class"   : shimmie2.Shimmie2TagExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://rule34hentai.net/_images/7f3a411263d0f6de936e47ae8f9d35fb/332%20-%20Darkstalkers%20Felicia%20mizuki_kotora.jpeg",
         "https://rule34hentai.net/_images/1a8eca7c04f8bf325bc993c5751a91c4/264%20-%20Darkstalkers%20Felicia%20mizuki_kotora.jpeg",
         "https://rule34hentai.net/_images/09511511c4c9e9e1f9b795e059a60832/259%20-%20Darkstalkers%20Felicia%20mizuki_kotora.jpeg",
@@ -34,7 +34,7 @@ __tests__ = (
     "#url"     : "https://rule34hentai.net/post/view/264",
     "#category": ("shimmie2", "rule34hentai", "post"),
     "#class"   : shimmie2.Shimmie2PostExtractor,
-    "#urls"        : "https://rule34hentai.net/_images/1a8eca7c04f8bf325bc993c5751a91c4/264%20-%20Darkstalkers%20Felicia%20mizuki_kotora.jpg",
+    "#results"     : "https://rule34hentai.net/_images/1a8eca7c04f8bf325bc993c5751a91c4/264%20-%20Darkstalkers%20Felicia%20mizuki_kotora.jpg",
     "#sha1_content": "6c23780bb78673cbff1bca9accb77ea11ec734f3",
 
     "extension": "jpg",

--- a/test/results/rule34vault.py
+++ b/test/results/rule34vault.py
@@ -83,7 +83,7 @@ __tests__ = (
     "#url"    : "https://rule34vault.com/post/382937",
     "#comment": "video",
     "#class"  : rule34vault.Rule34vaultPostExtractor,
-    "#urls"        : "https://r34xyz.b-cdn.net/posts/382/382937/382937.mp4",
+    "#results"     : "https://r34xyz.b-cdn.net/posts/382/382937/382937.mp4",
     "#sha1_content": "b962e3e2304139767c3792508353e6e83a85a2af",
 },
 

--- a/test/results/rule34xyz.py
+++ b/test/results/rule34xyz.py
@@ -32,7 +32,7 @@ __tests__ = (
     "#comment": "image",
     "#class"  : rule34xyz.Rule34xyzPostExtractor,
     "#options"     : {"tags": True},
-    "#urls"        : "https://rule34xyz.b-cdn.net/posts/3613/3613851/3613851.pic.jpg",
+    "#results"     : "https://rule34xyz.b-cdn.net/posts/3613/3613851/3613851.pic.jpg",
     "#sha1_content": "4d7146db258fd5b1645a1a5fc01550d102f495e1",
 
     "created"   : "2023-03-29T03:00:59.136819Z",
@@ -106,7 +106,7 @@ __tests__ = (
     "#url"    : "https://rule34.xyz/post/3571567",
     "#comment": "video",
     "#class"  : rule34xyz.Rule34xyzPostExtractor,
-    "#urls"        : "https://rule34xyz.b-cdn.net/posts/3571/3571567/3571567.mov720.mp4",
+    "#results"     : "https://rule34xyz.b-cdn.net/posts/3571/3571567/3571567.mov720.mp4",
     "#sha1_content": "c0a5e7e887774f91527f00e6142c435a3c482c1f",
 
     "format"   : "mov720",
@@ -118,7 +118,7 @@ __tests__ = (
     "#comment": "'format' option",
     "#class"  : rule34xyz.Rule34xyzPostExtractor,
     "#options": {"format": "10,4,5"},
-    "#urls"   : "https://rule34xyz.b-cdn.net/posts/3571/3571567/3571567.pic.jpg",
+    "#results": "https://rule34xyz.b-cdn.net/posts/3571/3571567/3571567.pic.jpg",
 
     "format"   : "pic",
     "format_id": "10",

--- a/test/results/saint.py
+++ b/test/results/saint.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"  : "https://saint2.su/a/2c5iuWHTumH",
     "#class": saint.SaintAlbumExtractor,
-    "#urls" : (
+    "#results": (
         "https://data.saint2.cr/data/3b1ccebf3576f8d5aac3ee0e5a12da95.mp4",
         "https://data.saint2.cr/data/3b125e3fb4b98693f17d85cb53590215.mp4",
     ),
@@ -40,7 +40,7 @@ __tests__ = (
 {
     "#url"  : "https://saint2.su/embed/6lC7mKrJst8",
     "#class": saint.SaintMediaExtractor,
-    "#urls"        : "https://data.saint2.cr/data/3b1ccebf3576f8d5aac3ee0e5a12da95.mp4",
+    "#results"     : "https://data.saint2.cr/data/3b1ccebf3576f8d5aac3ee0e5a12da95.mp4",
     "#sha1_content": "39037a029b3fe96f838b4545316caaa545c84075",
 
     "count"    : 1,
@@ -58,7 +58,7 @@ __tests__ = (
 {
     "#url"  : "https://saint2.su/d/M2IxMjVlM2ZiNGI5ODY5M2YxN2Q4NWNiNTM1OTAyMTUubXA0",
     "#class": saint.SaintMediaExtractor,
-    "#urls" : "https://data.saint2.cr/data/3b125e3fb4b98693f17d85cb53590215.mp4",
+    "#results": "https://data.saint2.cr/data/3b125e3fb4b98693f17d85cb53590215.mp4",
 
     "count"    : 1,
     "extension": "mp4",

--- a/test/results/sakugabooru.py
+++ b/test/results/sakugabooru.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#category": ("moebooru", "sakugabooru", "post"),
     "#class"   : moebooru.MoebooruPostExtractor,
     "#options" : {"tags": True},
-    "#urls"    : "https://www.sakugabooru.com/data/31db5edb23f7b5db590d182ea84a00b2.mp4",
+    "#results" : "https://www.sakugabooru.com/data/31db5edb23f7b5db590d182ea84a00b2.mp4",
 
     "actual_preview_height": 169,
     "actual_preview_width": 300,
@@ -78,7 +78,7 @@ __tests__ = (
     "#category": ("moebooru", "sakugabooru", "pool"),
     "#class"   : moebooru.MoebooruPoolExtractor,
     "#options" : {"metadata": True},
-    "#urls"    : (
+    "#results" : (
         "https://www.sakugabooru.com/data/cd1fe3601ddbb8b13db794a1f51acf36.gif",
         "https://www.sakugabooru.com/data/c6dedf058957f89126bcbdfd209bfc69.gif",
         "https://www.sakugabooru.com/data/3a8d6b7ec40fb66447d160d53759ec71.gif",

--- a/test/results/schalenetwork.py
+++ b/test/results/schalenetwork.py
@@ -131,9 +131,9 @@ __tests__ = (
     "#class"   : schalenetwork.SchalenetworkFavoriteExtractor,
     "#pattern" : schalenetwork.SchalenetworkGalleryExtractor.pattern,
     "#auth"    : True,
-    "#urls"    : [
+    "#results" : (
         "https://niyaniya.moe/g/14216/6c67076fdd45",
-    ],
+    ),
 },
 
 {
@@ -141,9 +141,9 @@ __tests__ = (
     "#class"   : schalenetwork.SchalenetworkFavoriteExtractor,
     "#pattern" : schalenetwork.SchalenetworkGalleryExtractor.pattern,
     "#auth"    : True,
-    "#urls"    : [
+    "#results" : (
         "https://niyaniya.moe/g/14216/6c67076fdd45",
-    ],
+    ),
 },
 
 )

--- a/test/results/scrolller.py
+++ b/test/results/scrolller.py
@@ -42,7 +42,7 @@ __tests__ = (
 {
     "#url"  : "https://scrolller.com/cabin-in-northern-finland-7nagf1929p",
     "#class": scrolller.ScrolllerPostExtractor,
-    "#urls" : "https://static.scrolller.com/yocto/cabin-in-northern-finland-93vjsuxmcz.jpg",
+    "#results": "https://static.scrolller.com/yocto/cabin-in-northern-finland-93vjsuxmcz.jpg",
 
     "count"           : 1,
     "displayName"     : None,
@@ -86,7 +86,7 @@ __tests__ = (
     "#url"    : "https://scrolller.com/some-quick-news-tboi-rule-34-mod-czedll1bum",
     "#comment": "album post with empty 'mediaSources' (#7428)",
     "#class"  : scrolller.ScrolllerPostExtractor,
-    "#urls"   : "https://static.scrolller.com/gamma/some-quick-news-tboi-rule-34-mod-1-50uolks94u.png",
+    "#results": "https://static.scrolller.com/gamma/some-quick-news-tboi-rule-34-mod-1-50uolks94u.png",
     "#count"  : 1,
 
     "count": 1,

--- a/test/results/sexcom.py
+++ b/test/results/sexcom.py
@@ -14,7 +14,7 @@ __tests__ = (
     "#category": ("", "sexcom", "pin"),
     "#class"   : sexcom.SexcomPinExtractor,
     "#skip"    : "legacy",
-    "#urls"        : "https://imagex1.sx.cdn.live/images/pinporn/2014/08/26/7637609.jpg",
+    "#results"     : "https://imagex1.sx.cdn.live/images/pinporn/2014/08/26/7637609.jpg",
     "#sha1_content": "8cd419c6790ef7348bd398c364ab10f956e438dc",
 
     "comments" : range(0, 5),
@@ -43,7 +43,7 @@ __tests__ = (
     "#comment" : "picture",
     "#category": ("", "sexcom", "pin"),
     "#class"   : sexcom.SexcomPinExtractor,
-    "#urls"    : "https://imagex1.sx.cdn.live/images/pinporn/2014/08/26/7637609.jpg",
+    "#results" : "https://imagex1.sx.cdn.live/images/pinporn/2014/08/26/7637609.jpg",
 
     "date"     : "dt:2014-08-26 00:00:00",
     "date_url" : "dt:2014-08-26 00:00:00",
@@ -60,7 +60,7 @@ __tests__ = (
     "#comment" : "gif (legacy URL)",
     "#category": ("", "sexcom", "pin"),
     "#class"   : sexcom.SexcomPinExtractor,
-    "#urls"        : "https://imagex1.sx.cdn.live/images/pinporn/2017/12/07/18760842.gif",
+    "#results"     : "https://imagex1.sx.cdn.live/images/pinporn/2017/12/07/18760842.gif",
     "#sha1_content": "176cc63fa05182cb0438c648230c0f324a5965fe",
 
     "date"     : "dt:2017-12-07 00:00:00",
@@ -84,7 +84,7 @@ __tests__ = (
     "#category": ("", "sexcom", "pin"),
     "#class"   : sexcom.SexcomPinExtractor,
     "#options" : {"gifs": False},
-    "#urls"        : "https://imagex1.sx.cdn.live/images/pinporn/2017/12/07/18760842.webp",
+    "#results"     : "https://imagex1.sx.cdn.live/images/pinporn/2017/12/07/18760842.webp",
     "#sha1_content": "d5d58fbb92f87be49a37d29d82687c9efa7f796f",
 
     "date"     : "dt:2017-12-07 00:00:00",
@@ -107,7 +107,7 @@ __tests__ = (
     "#category": ("", "sexcom", "pin"),
     "#class"   : sexcom.SexcomPinExtractor,
     "#skip"    : "gone",
-    "#urls"        : "https://video1.sx.cdn.live/videos/pinporn/2018/02/10/776229_hd.mp4",
+    "#results"     : "https://video1.sx.cdn.live/videos/pinporn/2018/02/10/776229_hd.mp4",
     "#sha1_content": "e1a5834869163e2c4d1ca2677f5b7b367cf8cfff",
 
     "comments" : range(0, 5),
@@ -133,7 +133,7 @@ __tests__ = (
     "#comment" : "video",
     "#category": ("", "sexcom", "pin"),
     "#class"   : sexcom.SexcomPinExtractor,
-    "#urls"    : "ytdl:https://videos.sex.com/680933/video.m3u8",
+    "#results" : "ytdl:https://videos.sex.com/680933/video.m3u8",
 
     "extension": "mp4",
     "pin_id"   : 680933,

--- a/test/results/smugmug.py
+++ b/test/results/smugmug.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "smugmug:album:cr4C7f",
     "#category": ("", "smugmug", "album"),
     "#class"   : smugmug.SmugmugAlbumExtractor,
-    "#urls": (
+    "#results": (
         "https://photos.smugmug.com/Nature/Dove/i-XvZFJFG/0/DMk7cm6qRBSFPvQgT9C4t4jtBJKF7JSK9jszgHZnr/O/Dual%20Suicide_20070721-DSC_4804.jpg",
         "https://photos.smugmug.com/Nature/Dove/i-2wVPqHf/0/DBXmTSTqVWzTLZxL3JPVK7hGT9zp8tzsFdhtWm68v/O/Morning%20Dove2_20070621-DSC_3222.jpg",
         "https://photos.smugmug.com/Nature/Dove/i-QHFnmb8/0/GKLvnm7zFQWX2G2VcJRprx8WZqTfFJkn8C5nRnCk/O/Speed%20Skater_03082008_POR7728.jpg",
@@ -53,7 +53,7 @@ __tests__ = (
     "#url"     : "https://tdm.smugmug.com/Nature/Dove/i-kCsLJT6",
     "#category": ("", "smugmug", "image"),
     "#class"   : smugmug.SmugmugImageExtractor,
-    "#urls"        : "https://photos.smugmug.com/Nature/Dove/i-kCsLJT6/0/FfB6gSx8X6MS7Hvww7GK7tWsrfdtwCx79hCVzwSm/O/Fluff_20090521-_DSC1542.jpg",
+    "#results"     : "https://photos.smugmug.com/Nature/Dove/i-kCsLJT6/0/FfB6gSx8X6MS7Hvww7GK7tWsrfdtwCx79hCVzwSm/O/Fluff_20090521-_DSC1542.jpg",
     "#sha1_content": "ecbd9d7b4f75a637abc8d35319be9ec065a44eb0",
 
     "Image": {
@@ -124,7 +124,7 @@ __tests__ = (
     "#comment" : "video",
     "#category": ("", "smugmug", "image"),
     "#class"   : smugmug.SmugmugImageExtractor,
-    "#urls"         : "https://photos.smugmug.com/Dailies/Daily-Dose-2015/i-39JFNzB/0/Q4Qg6kt4SqVcKsSLWM4PnhMhSTS2r5BkmBMd9Dx4/1920/657%20WS3-1920.mp4",
+    "#results"      : "https://photos.smugmug.com/Dailies/Daily-Dose-2015/i-39JFNzB/0/Q4Qg6kt4SqVcKsSLWM4PnhMhSTS2r5BkmBMd9Dx4/1920/657%20WS3-1920.mp4",
 },
 
 {

--- a/test/results/snootbooru.py
+++ b/test/results/snootbooru.py
@@ -20,7 +20,7 @@ __tests__ = (
     "#url"     : "https://snootbooru.com/post/14511",
     "#category": ("szurubooru", "snootbooru", "post"),
     "#class"   : szurubooru.SzurubooruPostExtractor,
-    "#urls"        : "https://snootbooru.com/data/posts/14511_e753313112755da6.png",
+    "#results"     : "https://snootbooru.com/data/posts/14511_e753313112755da6.png",
     "#sha1_content": "e69e61e61c5372514808480aae3a8e355c9cd6fb",
 
     "canvasHeight" : 1000,

--- a/test/results/tapas.py
+++ b/test/results/tapas.py
@@ -149,7 +149,7 @@ __tests__ = (
     "#url"     : "https://tapas.io/SANG123/series",
     "#comment" : "#5306",
     "#class"   : tapas.TapasCreatorExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://tapas.io/series/the-return-of-the-disaster-class-hero",
         "https://tapas.io/series/the-return-of-the-disaster-class-hero-novel",
         "https://tapas.io/series/tomb-raider-king",

--- a/test/results/tenor.py
+++ b/test/results/tenor.py
@@ -11,7 +11,7 @@ __tests__ = (
 {
     "#url"  : "https://tenor.com/view/moving-gif-8525772382434057283",
     "#class": tenor.TenorImageExtractor,
-    "#urls" : "https://media1.tenor.com/m/dlGgz3LRXEMAAAAC/moving.gif",
+    "#results": "https://media1.tenor.com/m/dlGgz3LRXEMAAAAC/moving.gif",
 
     "bg_color" : "",
     "description": "an illustration of a tree with green leaves",
@@ -65,14 +65,14 @@ __tests__ = (
     "#comment": "'format' option",
     "#class"  : tenor.TenorImageExtractor,
     "#options": {"format": ["mkv", "foobar", "webp"]},
-    "#urls"   : "https://media.tenor.com/dlGgz3LRXEMAAAAx/moving.webp",
+    "#results": "https://media.tenor.com/dlGgz3LRXEMAAAAx/moving.webp",
 },
 
 {
     "#url"    : "https://tenor.com/view/vtuber-hololive-%E3%83%9B%E3%83%AD%E3%83%A9%E3%82%A4%E3%83%96-hologra-%E3%83%9B%E3%83%AD%E3%81%90%E3%82%89-gif-26058046",
     "#comment": "non-ASCII characters in URL",
     "#class"  : tenor.TenorImageExtractor,
-    "#urls"   : "https://media1.tenor.com/m/jHugoUKy-T0AAAAC/vtuber-hololive.gif",
+    "#results": "https://media1.tenor.com/m/jHugoUKy-T0AAAAC/vtuber-hololive.gif",
 
     "id": "10122861201914526013",
 },
@@ -110,7 +110,7 @@ __tests__ = (
 {
     "#url"    : "https://tenor.com/users/robloxfan123",
     "#class"  : tenor.TenorUserExtractor,
-    "#urls"   : "https://media1.tenor.com/m/1auSjzCikuoAAAAC/2016-roblox.gif",
+    "#results": "https://media1.tenor.com/m/1auSjzCikuoAAAAC/2016-roblox.gif",
 
     "user": {
         "profile_id": "8180139772821505417",

--- a/test/results/tiktok.py
+++ b/test/results/tiktok.py
@@ -107,7 +107,7 @@ __tests__ = (
     "#comment"  : "Video post",
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
-    "#urls"     : "ytdl:https://www.tiktok.com/@memezar/video/7449708266168274208",
+    "#results"  : "ytdl:https://www.tiktok.com/@memezar/video/7449708266168274208",
     "#options"  : {"videos": True, "audio": True},
 },
 
@@ -116,7 +116,7 @@ __tests__ = (
     "#comment"  : "Video post as a /photo/ link",
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
-    "#urls"     : "ytdl:https://www.tiktok.com/@memezar/video/7449708266168274208",
+    "#results"  : "ytdl:https://www.tiktok.com/@memezar/video/7449708266168274208",
     "#options"  : {"videos": True, "audio": True},
 },
 
@@ -145,7 +145,7 @@ __tests__ = (
     "#comment"  : "Video post as a share link",
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
-    "#urls"     : "ytdl:https://www.tiktok.com/@/video/7449708266168274208",
+    "#results"  : "ytdl:https://www.tiktok.com/@/video/7449708266168274208",
     "#options"  : {"videos": True},
 },
 
@@ -154,7 +154,7 @@ __tests__ = (
     "#comment"  : "Skipping video post",
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
-    "#urls"     : [],
+    "#results"  : (),
     "#options"  : {"videos": False},
 },
 

--- a/test/results/tumblr.py
+++ b/test/results/tumblr.py
@@ -237,7 +237,7 @@ __tests__ = (
     "#category": ("", "tumblr", "post"),
     "#class"   : tumblr.TumblrPostExtractor,
     "#options"     : {"retries": 0},
-    "#urls"        : "https://64.media.tumblr.com/5e9d760aba24c65beaf0e72de5aae4dd/tumblr_psj5yaqV871t1ig6no1_1280.gif",
+    "#results"     : "https://64.media.tumblr.com/5e9d760aba24c65beaf0e72de5aae4dd/tumblr_psj5yaqV871t1ig6no1_1280.gif",
     "#sha1_content": "3508d894b6cc25e364d182a8e1ff370d706965fb",
 },
 

--- a/test/results/twibooru.py
+++ b/test/results/twibooru.py
@@ -63,7 +63,7 @@ __tests__ = (
     "#comment" : "svg (#5643)",
     "#category": ("philomena", "twibooru", "post"),
     "#class"   : twibooru.TwibooruPostExtractor,
-    "#urls"        : "https://cdn.twibooru.org/img/2020/7/13/523964/full.svg",
+    "#results"     : "https://cdn.twibooru.org/img/2020/7/13/523964/full.svg",
     "#sha1_content": "15590fe151ff65ef767b409e46dfdf708b339f4d",
 
     "extension": "svg",
@@ -76,7 +76,7 @@ __tests__ = (
     "#category": ("philomena", "twibooru", "post"),
     "#class"   : twibooru.TwibooruPostExtractor,
     "#options" : {"svg": False},
-    "#urls"        : "https://cdn.twibooru.org/img/2020/7/13/523964/full.png",
+    "#results"     : "https://cdn.twibooru.org/img/2020/7/13/523964/full.png",
     "#sha1_content": "f8ff78e6a929a024f8529199f9a600617898d03c",
 
     "extension": "png",

--- a/test/results/twitter.py
+++ b/test/results/twitter.py
@@ -14,7 +14,7 @@ __tests__ = (
     "#category": ("", "twitter", "user"),
     "#class"   : twitter.TwitterUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : [
+    "#results" : (
         "https://x.com/supernaturepics/info",
         "https://x.com/supernaturepics/photo",
         "https://x.com/supernaturepics/header_photo",
@@ -23,7 +23,7 @@ __tests__ = (
         "https://x.com/supernaturepics/media",
         "https://x.com/supernaturepics/with_replies",
         "https://x.com/supernaturepics/likes",
-    ],
+    ),
 },
 
 {
@@ -291,7 +291,7 @@ __tests__ = (
     "#category": ("", "twitter", "hashtag"),
     "#class"   : twitter.TwitterHashtagExtractor,
     "#pattern" : twitter.TwitterSearchExtractor.pattern,
-    "#urls"    : "https://x.com/search?q=%23nature",
+    "#results" : "https://x.com/search?q=%23nature",
 },
 
 {
@@ -656,7 +656,7 @@ The Washington Post writes, "Three weeks after the toxic train derailment in Ohi
     "#category": ("", "twitter", "tweet"),
     "#class"   : twitter.TwitterTweetExtractor,
     "#options" : {"cards": True},
-    "#urls"    : "https://pbs.twimg.com/grok-img-share/1866736156786008064.jpg",
+    "#results" : "https://pbs.twimg.com/grok-img-share/1866736156786008064.jpg",
 },
 
 {
@@ -664,7 +664,7 @@ The Washington Post writes, "Three weeks after the toxic train derailment in Ohi
     "#comment" : "'source_id' and 'source_user' metadata (#7470, #7640)",
     "#category": ("", "twitter", "tweet"),
     "#class"   : twitter.TwitterTweetExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://video.twimg.com/amplify_video/1932079443264376832/vid/avc1/640x336/7xo7NCPkMLRWb8NZ.mp4?tag=14",
         "https://video.twimg.com/ext_tw_video/1930425322333229056/pu/vid/avc1/1024x576/6f_cdEPY3a5CcbZP.mp4?tag=12",
     ),
@@ -680,7 +680,7 @@ The Washington Post writes, "Three weeks after the toxic train derailment in Ohi
     "#category": ("", "twitter", "quotes"),
     "#class"   : twitter.TwitterQuotesExtractor,
     "#pattern" : twitter.TwitterSearchExtractor.pattern,
-    "#urls"    : "https://x.com/search?q=quoted_tweet_id:1263832915173048321",
+    "#results" : "https://x.com/search?q=quoted_tweet_id:1263832915173048321",
 },
 
 {
@@ -693,7 +693,7 @@ The Washington Post writes, "Three weeks after the toxic train derailment in Ohi
     "#url"     : "https://twitter.com/supernaturepics/photo",
     "#category": ("", "twitter", "avatar"),
     "#class"   : twitter.TwitterAvatarExtractor,
-    "#urls"    : "https://pbs.twimg.com/profile_images/554585280938659841/FLVAlX18.jpeg",
+    "#results" : "https://pbs.twimg.com/profile_images/554585280938659841/FLVAlX18.jpeg",
 
     "date"     : "dt:2015-01-12 10:26:49",
     "extension": "jpeg",
@@ -713,7 +713,7 @@ The Washington Post writes, "Three weeks after the toxic train derailment in Ohi
     "#comment" : "old avatar with small ID and no valid 'date' (#4696)",
     "#category": ("", "twitter", "avatar"),
     "#class"   : twitter.TwitterAvatarExtractor,
-    "#urls"    : "https://pbs.twimg.com/profile_images/2946444489/32028c6affdab425e037ff5a6bf77c1d.jpeg",
+    "#results" : "https://pbs.twimg.com/profile_images/2946444489/32028c6affdab425e037ff5a6bf77c1d.jpeg",
 
     "date"     : util.NONE,
     "tweet_id" : 2946444489,

--- a/test/results/twitter.py
+++ b/test/results/twitter.py
@@ -334,7 +334,9 @@ __tests__ = (
     "#class"   : twitter.TwitterTweetExtractor,
     "#sha1_url": "3a2a43dc5fb79dd5432c701d8e55e87c4e551f47",
 
-    "type": "photo",
+    "type"        : "photo",
+    "source_id"   : 0,
+    "!source_user": dict,
 },
 
 {
@@ -655,6 +657,22 @@ The Washington Post writes, "Three weeks after the toxic train derailment in Ohi
     "#class"   : twitter.TwitterTweetExtractor,
     "#options" : {"cards": True},
     "#urls"    : "https://pbs.twimg.com/grok-img-share/1866736156786008064.jpg",
+},
+
+{
+    "#url"     : "https://x.com/gdldev/status/1932109706354733077",
+    "#comment" : "'source_id' and 'source_user' metadata (#7470, #7640)",
+    "#category": ("", "twitter", "tweet"),
+    "#class"   : twitter.TwitterTweetExtractor,
+    "#urls"    : (
+        "https://video.twimg.com/amplify_video/1932079443264376832/vid/avc1/640x336/7xo7NCPkMLRWb8NZ.mp4?tag=14",
+        "https://video.twimg.com/ext_tw_video/1930425322333229056/pu/vid/avc1/1024x576/6f_cdEPY3a5CcbZP.mp4?tag=12",
+    ),
+
+    "source_id"  : {1932079546590982508, 1930425346404274416},
+    "source_user": {
+        "name": {"Satorin69", "Derlan144p_"},
+    },
 },
 
 {

--- a/test/results/urlgalleries.py
+++ b/test/results/urlgalleries.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#category": ("", "urlgalleries", "gallery"),
     "#class"   : urlgalleries.UrlgalleriesGalleryExtractor,
     "#range"   : "1-3",
-    "#urls"    : (
+    "#results" : (
         "https://fappic.com/x207mqkn2463/4gq1yv.jpg",
         "https://fappic.com/q684ua2rp0j9/4gq1xv.jpg",
         "https://fappic.com/8vf3n8fgz9po/4gq1ya.jpg",
@@ -32,7 +32,7 @@ __tests__ = (
     "#category": ("", "urlgalleries", "gallery"),
     "#class"   : urlgalleries.UrlgalleriesGalleryExtractor,
     "#range"   : "1-3",
-    "#urls"    : (
+    "#results" : (
         "https://fappic.com/x207mqkn2463/4gq1yv.jpg",
         "https://fappic.com/q684ua2rp0j9/4gq1xv.jpg",
         "https://fappic.com/8vf3n8fgz9po/4gq1ya.jpg",
@@ -51,7 +51,7 @@ __tests__ = (
     "#category": ("", "urlgalleries", "gallery"),
     "#class"   : urlgalleries.UrlgalleriesGalleryExtractor,
     "#range"   : "1-3",
-    "#urls"    : (
+    "#results" : (
         "https://www.fappic.com/vj7up04ny487/AmourAngels-0001.jpg",
         "https://www.fappic.com/zfgsmpm36iyv/AmourAngels-0002.jpg",
         "https://www.fappic.com/rqpt37rdbwa5/AmourAngels-0003.jpg",

--- a/test/results/visuabusters.py
+++ b/test/results/visuabusters.py
@@ -32,7 +32,7 @@ __tests__ = (
     "#url"     : "https://www.visuabusters.com/booru/post/2485",
     "#category": ("szurubooru", "visuabusters", "post"),
     "#class"   : szurubooru.SzurubooruPostExtractor,
-    "#urls"        : "https://www.visuabusters.com/booru/data/posts/visuabusters_2485_ynmXFhNmBs3x0cCm.gif",
+    "#results"     : "https://www.visuabusters.com/booru/data/posts/visuabusters_2485_ynmXFhNmBs3x0cCm.gif",
     "#sha1_content": "781fc0f063503d9d3f282558b9fcd69e37045e88",
 },
 

--- a/test/results/vsco.py
+++ b/test/results/vsco.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://vsco.co/missuri",
     "#category": ("", "vsco", "user"),
     "#class"   : vsco.VscoUserExtractor,
-    "#urls"    : "https://vsco.co/missuri/gallery",
+    "#results" : "https://vsco.co/missuri/gallery",
 },
 
 {
@@ -20,12 +20,12 @@ __tests__ = (
     "#category": ("", "vsco", "user"),
     "#class"   : vsco.VscoUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : [
+    "#results" : (
         "https://vsco.co/missuri/avatar",
         "https://vsco.co/missuri/gallery",
         "https://vsco.co/missuri/spaces",
         "https://vsco.co/missuri/collection",
-    ],
+    ),
 },
 
 {
@@ -86,7 +86,7 @@ __tests__ = (
     "#url"     : "https://vsco.co/missuri/spaces",
     "#category": ("", "vsco", "spaces"),
     "#class"   : vsco.VscoSpacesExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://vsco.co/spaces/62e4934e6920440801d19f05",
     ),
 },

--- a/test/results/wallpapercave.py
+++ b/test/results/wallpapercave.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://wallpapercave.com/w/wp10270355",
     "#category": ("", "wallpapercave", "image"),
     "#class"   : wallpapercave.WallpapercaveImageExtractor,
-    "#urls"        : "https://wallpapercave.com/download/sekai-saikou-no-ansatsusha-isekai-kizoku-ni-tensei-suru-wallpapers-wp10270355",
+    "#results"     : "https://wallpapercave.com/download/sekai-saikou-no-ansatsusha-isekai-kizoku-ni-tensei-suru-wallpapers-wp10270355",
     "#sha1_content": "58b088aaa1cf1a60e347015019eb0c5a22b263a6",
 },
 
@@ -22,12 +22,12 @@ __tests__ = (
     "#category": ("", "wallpapercave", "image"),
     "#class"   : wallpapercave.WallpapercaveImageExtractor,
     "#archive" : False,
-    "#urls"    : [
+    "#results" : (
         "https://wallpapercave.com/wp/wp13775438.jpg",
         "https://wallpapercave.com/wp/wp13775439.jpg",
         "https://wallpapercave.com/wp/wp13775440.jpg",
         "https://wallpapercave.com/wp/wp13775441.jpg",
-    ],
+    ),
 },
 
 )

--- a/test/results/warosu.py
+++ b/test/results/warosu.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://warosu.org/jp/thread/16656025",
     "#category": ("", "warosu", "thread"),
     "#class"   : warosu.WarosuThreadExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://i.warosu.org/data/jp/img/0166/56/1488487280004.png",
         "https://i.warosu.org/data/jp/img/0166/56/1488493239417.png",
         "https://i.warosu.org/data/jp/img/0166/56/1488493636725.jpg",
@@ -32,7 +32,7 @@ __tests__ = (
     "#category": ("", "warosu", "thread"),
     "#class"   : warosu.WarosuThreadExtractor,
     "#sha1_content" : "d48df0a701e6599312bfff8674f4aa5d4fb8db1c",
-    "#urls"         : "https://i.warosu.org/data/jp/img/0166/58/1488521824388.jpg",
+    "#results"      : "https://i.warosu.org/data/jp/img/0166/58/1488521824388.jpg",
     "#count"        : 1,
 
     "board"     : "jp",

--- a/test/results/webtoons.py
+++ b/test/results/webtoons.py
@@ -14,7 +14,7 @@ __tests__ = (
     "#category": ("", "webtoons", "episode"),
     "#class"   : webtoons.WebtoonsEpisodeExtractor,
     "#count"       : 5,
-    "#urls"        : (
+    "#results"     : (
         "https://swebtoon-phinf.pstatic.net/20200513_191/1589322488148XfdRr_PNG/15893224850013525720.png?type=opti",
         "https://swebtoon-phinf.pstatic.net/20200513_143/1589322489499KJLvU_PNG/15893224866183525723.png?type=opti",
         "https://swebtoon-phinf.pstatic.net/20200513_281/15893224881499wbH7_PNG/15893224865073525729.png?type=opti",
@@ -64,7 +64,7 @@ __tests__ = (
     "#url"     : "https://www.webtoons.com/en/canvas/i-want-to-be-a-cute-anime-girl/209-the-storys-story/viewer?title_no=349416&episode_no=214",
     "#category": ("", "webtoons", "episode"),
     "#class"   : webtoons.WebtoonsEpisodeExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://swebtoon-phinf.pstatic.net/20220121_262/1642763563000TUsiC_JPEG/7ddc535a-0bde-40df-ab62-f912aed1c751.jpg",
         "https://swebtoon-phinf.pstatic.net/20220121_152/1642763564219c8T9I_JPEG/73ccdf9f-c46c-4760-8553-799713300fd7.jpg",
         "https://swebtoon-phinf.pstatic.net/20220121_80/16427635653964Eh5i_JPEG/1bd3c498-656b-4b1f-bf22-e25c01a01679.jpg",
@@ -83,7 +83,7 @@ __tests__ = (
     "#category": ("", "webtoons", "episode"),
     "#class"   : webtoons.WebtoonsEpisodeExtractor,
     "#options" : {"quality": 50},
-    "#urls"    : (
+    "#results" : (
         "https://swebtoon-phinf.pstatic.net/20210629_102/1624911944660PIYD2_JPEG/27c5312d-7b9b-4b75-8026-526e9a55331a.jpg?type=q50",
         "https://swebtoon-phinf.pstatic.net/20210629_295/1624911951107dhQEw_JPEG/fc4bd86a-effc-4f0e-88d5-8c48d6ec3902.jpg?type=q50",
         "https://swebtoon-phinf.pstatic.net/20210629_293/16249119579830kbnl_JPEG/96203608-31e7-4f1c-a9e0-db5d43457884.jpg?type=q50",
@@ -102,7 +102,7 @@ __tests__ = (
     "#category": ("", "webtoons", "episode"),
     "#class"   : webtoons.WebtoonsEpisodeExtractor,
     "#options" : {"quality": {"jpg": "q0", "jpeg": "q100", "png": False}},
-    "#urls"    : (
+    "#results" : (
         "https://swebtoon-phinf.pstatic.net/20240125_32/17061125731244mMCw_JPEG/0001.JPEG?type=q100",
         "https://swebtoon-phinf.pstatic.net/20240125_290/1706112575827OXqUk_JPEG/0059.JPEG?type=q100",
         "https://swebtoon-phinf.pstatic.net/20240125_211/1706112575860p6rEU_JPEG/0060.JPEG?type=q100",
@@ -163,7 +163,7 @@ __tests__ = (
 {
     "#url"     : "https://www.webtoons.com/p/community/en/u/g6vj8",
     "#class"   : webtoons.WebtoonsArtistExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://www.webtoons.com/en/canvas/scoob-and-shag/list?title_no=210827",
         "https://www.webtoons.com/en/canvas/sparkle-kid/list?title_no=205304",
     ),

--- a/test/results/weibo.py
+++ b/test/results/weibo.py
@@ -13,7 +13,7 @@ __tests__ = (
     "#url"     : "https://weibo.com/1758989602",
     "#category": ("", "weibo", "user"),
     "#class"   : weibo.WeiboUserExtractor,
-    "#urls"    : "https://weibo.com/u/1758989602?tabtype=feed",
+    "#results" : "https://weibo.com/u/1758989602?tabtype=feed",
 },
 
 {
@@ -21,7 +21,7 @@ __tests__ = (
     "#category": ("", "weibo", "user"),
     "#class"   : weibo.WeiboUserExtractor,
     "#options" : {"include": "all"},
-    "#urls"    : (
+    "#results" : (
         "https://weibo.com/u/1758989602?tabtype=home",
         "https://weibo.com/u/1758989602?tabtype=feed",
         "https://weibo.com/u/1758989602?tabtype=video",
@@ -34,14 +34,14 @@ __tests__ = (
     "#url"     : "https://weibo.com/zhouyuxi77",
     "#category": ("", "weibo", "user"),
     "#class"   : weibo.WeiboUserExtractor,
-    "#urls"    : "https://weibo.com/u/7488709788?tabtype=feed",
+    "#results" : "https://weibo.com/u/7488709788?tabtype=feed",
 },
 
 {
     "#url"     : "https://www.weibo.com/n/周于希Sally",
     "#category": ("", "weibo", "user"),
     "#class"   : weibo.WeiboUserExtractor,
-    "#urls"    : "https://weibo.com/u/7488709788?tabtype=feed",
+    "#results" : "https://weibo.com/u/7488709788?tabtype=feed",
 },
 
 {
@@ -243,7 +243,7 @@ __tests__ = (
     "#comment" : "type == gif",
     "#category": ("", "weibo", "status"),
     "#class"   : weibo.WeiboStatusExtractor,
-    "#urls"    : "https://wx4.sinaimg.cn/large/68d80d22gy1h2ryfa8k0kg208w06o7wh.gif",
+    "#results" : "https://wx4.sinaimg.cn/large/68d80d22gy1h2ryfa8k0kg208w06o7wh.gif",
 
     "extension": "gif",
 },
@@ -288,7 +288,7 @@ __tests__ = (
     "#category": ("", "weibo", "status"),
     "#class"   : weibo.WeiboStatusExtractor,
     "#options" : {"movies": True},
-    "#urls"    : (
+    "#results" : (
         "https://wx4.sinaimg.cn/large/7261e0e1gy1frvyc1xnkfj20qo0zkwjh.jpg",
         "https://wx2.sinaimg.cn/large/7261e0e1gy1frvyc30b1jj20zk0qojwh.jpg",
         "https://wx4.sinaimg.cn/large/7261e0e1gy1frvyc44lx8j20qo0zk7a6.jpg",

--- a/test/results/wikiart.py
+++ b/test/results/wikiart.py
@@ -72,7 +72,7 @@ __tests__ = (
     "#category": ("", "wikiart", "image"),
     "#class"   : wikiart.WikiartImageExtractor,
     "#sha1_url": "d7f60118c34067b2b37d9577e412dc1477b94207",
-    "#urls"    : (
+    "#results" : (
         "https://uploads5.wikiart.org/images/huang-shen/summer.jpg",
     ),
 },
@@ -82,7 +82,7 @@ __tests__ = (
     "#category": ("", "wikiart", "artworks"),
     "#class"   : wikiart.WikiartArtworksExtractor,
     "#sha1_url": "36e054fcb3363b7f085c81f4778e6db3994e56a3",
-    "#urls"    : (
+    "#results" : (
         "https://uploads4.wikiart.org/images/hieronymus-bosch/triptych-of-last-judgement.jpg",
         "https://uploads6.wikiart.org/images/hieronymus-bosch/triptych-of-last-judgement-1.jpg",
         "https://uploads0.wikiart.org/images/hieronymus-bosch/tiptych-of-temptation-of-st-anthony-1506.jpg",

--- a/test/results/wikimediacommons.py
+++ b/test/results/wikimediacommons.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://commons.wikimedia.org/wiki/File:Starr-050516-1367-Pimenta_dioica-flowers-Maunaloa-Molokai_(24762757525).jpg",
     "#category": ("wikimedia", "wikimediacommons", "file"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#urls"    : "https://upload.wikimedia.org/wikipedia/commons/f/fa/Starr-050516-1367-Pimenta_dioica-flowers-Maunaloa-Molokai_%2824762757525%29.jpg",
+    "#results" : "https://upload.wikimedia.org/wikipedia/commons/f/fa/Starr-050516-1367-Pimenta_dioica-flowers-Maunaloa-Molokai_%2824762757525%29.jpg",
 },
 
 {
@@ -28,7 +28,7 @@ __tests__ = (
     "#class"   : wikimedia.WikimediaArticleExtractor,
     "#options" : {"image-filter": "False"},
 
-    "#urls": (
+    "#results": (
         "https://commons.wikimedia.org/wiki/Category:3558_Shishkin",
         "https://commons.wikimedia.org/wiki/Category:Drawings_by_Ivan_Shishkin",
         "https://commons.wikimedia.org/wiki/Category:Ivan_Shishkin_grave",

--- a/test/results/wikispecies.py
+++ b/test/results/wikispecies.py
@@ -12,7 +12,7 @@ __tests__ = (
     "#url"     : "https://species.wikimedia.org/wiki/Geranospiza",
     "#category": ("wikimedia", "wikispecies", "article"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#urls"        : "https://upload.wikimedia.org/wikipedia/commons/0/01/Geranospiza_caerulescens.jpg",
+    "#results"     : "https://upload.wikimedia.org/wikipedia/commons/0/01/Geranospiza_caerulescens.jpg",
     "#sha1_content": "3a17c14b15489928e4154f826af1c42afb5a523e",
 },
 

--- a/test/results/xbooru.py
+++ b/test/results/xbooru.py
@@ -19,7 +19,7 @@ __tests__ = (
     "#url"     : "https://xbooru.com/index.php?page=pool&s=show&id=757",
     "#category": ("gelbooru_v02", "xbooru", "pool"),
     "#class"   : gelbooru_v02.GelbooruV02PoolExtractor,
-    "#urls": (
+    "#results": (
         "https://img.xbooru.com/images/154/aeca160f8c7131f6a93033adac5416d7.jpeg",
         "https://img.xbooru.com/images/278/6185a8a71547568020e45e8319c02978.jpeg",
         "https://img.xbooru.com/images/524/0fc2b1e2e3cc8be259e9712ca3f48b0b.jpeg",

--- a/test/results/xfolio.py
+++ b/test/results/xfolio.py
@@ -12,7 +12,7 @@ __tests__ = (
 {
     "#url"     : "https://xfolio.jp/portfolio/yutakashii/works/23977",
     "#class"   : xfolio.XfolioWorkExtractor,
-    "#urls"    : (
+    "#results" : (
         "https://xfolio.jp/user_asset.php?id=113179&work_id=23977&work_image_id=113179&type=work_image",
         "https://xfolio.jp/user_asset.php?id=113182&work_id=23977&work_image_id=113182&type=work_image",
         "https://xfolio.jp/user_asset.php?id=113185&work_id=23977&work_image_id=113185&type=work_image",
@@ -79,7 +79,7 @@ __tests__ = (
     "#url"     : "https://xfolio.jp/portfolio/donguri/series/1391402",
     "#class"   : xfolio.XfolioSeriesExtractor,
     "#auth"    : True,
-    "#urls"    : (
+    "#results" : (
         "https://xfolio.jp/portfolio/donguri/works/2472402",
         "https://xfolio.jp/portfolio/donguri/works/2470700",
     ),

--- a/test/results/yandere.py
+++ b/test/results/yandere.py
@@ -60,7 +60,7 @@ __tests__ = (
     "#category": ("moebooru", "yandere", "pool"),
     "#class"   : moebooru.MoebooruPoolExtractor,
     "#sha1_content": "2a35b9d6edecce11cc2918c6dce4de2198342b68",
-    "#urls"        : (
+    "#results"     : (
         "https://files.yande.re/image/62558ad1d68ffb47e903694d2c5f9e53/yande.re%2051824%20armor%20ouzoku%20pantsu%20sasaki_tamaru%20softhouse_chara%20sword%20thighhighs.jpg",
         "https://files.yande.re/image/c57fcd886f643297f1283242e572b81d/yande.re%2036975%20ashita_no_kimi_to_au_tame_ni%20cleavage%20kurashima_tomoyasu%20pantsu%20wakamiya_asuka.jpg",
         "https://files.yande.re/image/c877ec0dc18dd79d69217011adfa5af3/yande.re%2051832%20aburidashi_zakuro%20animal_ears%20erect_nipples%20pantsu%20tail.jpg",

--- a/test/results/yiffverse.py
+++ b/test/results/yiffverse.py
@@ -56,7 +56,7 @@ __tests__ = (
     "#url"    : "https://yiffverse.com/post/575680",
     "#comment": "video",
     "#class"  : yiffverse.YiffversePostExtractor,
-    "#urls"        : "https://yiffverse.com/posts/575/575680/575680.mov.mp4",
+    "#results"     : "https://yiffverse.com/posts/575/575680/575680.mov.mp4",
     "#sha1_content": "8952fc794e58c531b4e3b01cfe9e14b1c59ad9ef",
 },
 

--- a/test/results/zerochan.py
+++ b/test/results/zerochan.py
@@ -119,7 +119,7 @@ __tests__ = (
     "#url"     : "https://www.zerochan.net/4233756",
     "#category": ("booru", "zerochan", "image"),
     "#class"   : zerochan.ZerochanImageExtractor,
-    "#urls"    : "https://static.zerochan.net/DRAGON.BALL.full.4233756.jpg",
+    "#results" : "https://static.zerochan.net/DRAGON.BALL.full.4233756.jpg",
     "#options" : {"tags": True},
 
     "author"   : "Raydash",
@@ -181,7 +181,7 @@ __tests__ = (
     "#url"     : "https://www.zerochan.net/4233756",
     "#class"   : zerochan.ZerochanImageExtractor,
     "#auth"    : False,
-    "#urls"    : "https://static.zerochan.net/DRAGON.BALL.full.4233756.jpg",
+    "#results" : "https://static.zerochan.net/DRAGON.BALL.full.4233756.jpg",
 
     "source"   : "https://x.com/Raydash30/status/1766012730769862774",
     "tags"     : [

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -223,8 +223,7 @@ class TestConfigFiles(unittest.TestCase):
         self.assertIsInstance(cfg, dict)
         self.assertTrue(cfg)
 
-    @staticmethod
-    def _load(name):
+    def _load(self, name):
         path = os.path.join(ROOTDIR, "docs", name)
         try:
             with open(path) as fp:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_cookies.py
+++ b/test/test_cookies.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2017-2023 Mike Fährmann
+# Copyright 2017-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_downloader.py
+++ b/test/test_downloader.py
@@ -369,6 +369,7 @@ SAMPLES = {
     ("heic", b"????ftypheis"),
     ("heic", b"????ftypheix"),
     ("svg" , b"<?xml"),
+    ("html", b"<!DOCTYPE html><html>...</html>"),
     ("ico" , b"\x00\x00\x01\x00"),
     ("cur" , b"\x00\x00\x02\x00"),
     ("psd" , b"8BPS"),

--- a/test/test_downloader.py
+++ b/test/test_downloader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2022 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2018-2023 Mike Fährmann
+# Copyright 2018-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -296,8 +296,7 @@ class TestExtractorWait(unittest.TestCase):
         u = self._isotime_to_seconds(until.time().isoformat()[:8])
         self.assertLessEqual(o-u, 1.0)
 
-    @staticmethod
-    def _isotime_to_seconds(isotime):
+    def _isotime_to_seconds(self, isotime):
         parts = isotime.split(":")
         return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
 

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2021-2023 Mike Fährmann
+# Copyright 2021-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -10,7 +10,7 @@
 import os
 import sys
 import unittest
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, mock_open, patch, call
 
 import shutil
 import logging
@@ -232,6 +232,38 @@ class ExecTest(BasePostprocessorTest):
             ],
             shell=False,
         )
+
+    def test_command_many(self):
+        self._create({
+            "commands": [
+                "echo {} {_path} {_directory} {_filename} && rm {};",
+                ["~/script.sh", "{category}", "\fE _directory.upper()"],
+            ]
+        })
+
+        with patch("gallery_dl.util.Popen") as p:
+            i = Mock()
+            i.wait.return_value = 0
+            p.return_value = i
+            self._trigger(("after",))
+
+        self.assertEqual(p.call_args_list, [
+            call(
+                "echo {0} {0} {1} {2} && rm {0};".format(
+                    self.pathfmt.realpath,
+                    self.pathfmt.realdirectory,
+                    self.pathfmt.filename),
+                shell=True,
+            ),
+            call(
+                [
+                    os.path.expanduser("~/script.sh"),
+                    self.pathfmt.kwdict["category"],
+                    self.pathfmt.realdirectory.upper(),
+                ],
+                shell=False,
+            ),
+        ])
 
     def test_command_returncode(self):
         self._create({
@@ -944,8 +976,8 @@ class ZipTest(BasePostprocessorTest):
         self._trigger(("finalize",))
 
         self.assertEqual(pp.zfile.write.call_count, 3)
-        for call in pp.zfile.write.call_args_list:
-            args, kwargs = call
+        for call_args in pp.zfile.write.call_args_list:
+            args, kwargs = call_args
             self.assertEqual(len(args), 2)
             self.assertEqual(len(kwargs), 0)
             self.assertEqual(args[0], self.pathfmt.temppath)

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -713,8 +713,7 @@ class MetadataTest(BasePostprocessorTest):
 }
 """)
 
-    @staticmethod
-    def _output(mock):
+    def _output(self, mock):
         return "".join(
             call[1][0]
             for call in mock.mock_calls

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2019-2023 Mike Fährmann
+# Copyright 2019-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -242,13 +242,15 @@ class TestExtractorResults(unittest.TestCase):
                 for url, pat in zip(tjob.url_list, pattern):
                     self.assertRegex(url, pat, msg="#pattern")
 
-        if "#urls" in result:
-            expected = result["#urls"]
+        if "#results" in result:
+            expected = result["#results"]
             if isinstance(expected, str):
-                self.assertTrue(tjob.url_list, msg="#urls")
-                self.assertEqual(tjob.url_list[0], expected, msg="#urls")
+                self.assertTrue(tjob.url_list, msg="#results")
+                self.assertEqual(
+                    tjob.url_list[0], expected, msg="#results")
             else:
-                self.assertSequenceEqual(tjob.url_list, expected, msg="#urls")
+                self.assertSequenceEqual(
+                    tjob.url_list, expected, msg="#results")
 
         metadata = {k: v for k, v in result.items() if k[0] != "#"}
         if metadata:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2015-2023 Mike Fährmann
+# Copyright 2015-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -28,11 +28,18 @@ from gallery_dl import util, text, exception  # noqa E402
 
 class TestRange(unittest.TestCase):
 
-    def test_parse_empty(self, f=util.RangePredicate._parse):
+    def setUp(self):
+        self.predicate = util.RangePredicate("")
+
+    def test_parse_empty(self):
+        f = self.predicate._parse
+
         self.assertEqual(f(""), [])
         self.assertEqual(f([]), [])
 
-    def test_parse_digit(self, f=util.RangePredicate._parse):
+    def test_parse_digit(self):
+        f = self.predicate._parse
+
         self.assertEqual(f("2"), [range(2, 3)])
 
         self.assertEqual(
@@ -42,7 +49,9 @@ class TestRange(unittest.TestCase):
              range(4, 5)],
         )
 
-    def test_parse_range(self, f=util.RangePredicate._parse):
+    def test_parse_range(self):
+        f = self.predicate._parse
+
         self.assertEqual(f("1-2"), [range(1, 3)])
         self.assertEqual(f("2-"), [range(2, sys.maxsize)])
         self.assertEqual(f("-3"), [range(1, 4)])
@@ -62,7 +71,9 @@ class TestRange(unittest.TestCase):
              range(2, 7)],
         )
 
-    def test_parse_slice(self, f=util.RangePredicate._parse):
+    def test_parse_slice(self):
+        f = self.predicate._parse
+
         self.assertEqual(f("2:4")  , [range(2, 4)])
         self.assertEqual(f("3::")  , [range(3, sys.maxsize)])
         self.assertEqual(f(":4:")  , [range(1, 4)])

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -161,6 +161,10 @@ class TestPredicate(unittest.TestCase):
 
         self.assertFalse(pred(url, {"a": 2}))
 
+        pred = util.FilterPredicate("re.search(r'.+', url)")
+        self.assertTrue(pred(url, {"url": "https://example.org/"}))
+        self.assertFalse(pred(url, {"url": ""}))
+
     def test_build_predicate(self):
         pred = util.build_predicate([])
         self.assertIsInstance(pred, type(lambda: True))

--- a/test/test_ytdl.py
+++ b/test/test_ytdl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2022-2023 Mike Fährmann
+# Copyright 2022-2025 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `06e2f2c..40dedd7`
**Files Changed:** 261 (260 programming files)
**Programming Ratio:** 99.6%

**Commits included:**
- [util] restore stdlib 're' module in filter expressions (#7665)
- [pp:exec] implement 'commands' option
- [pinterest] remove excess whitespace from 'description' fields (#4335)
- [tests:results] rename '#urls' to '#results'
- update copyright notices
- remove @staticmethod decorators
- [dl:http] add MIME type and signature for .html files
- [fantia] prevent '.html' file downloads
- [twitter] extract 'source_id' and 'source_user' metadata (#7470 #7640)